### PR TITLE
BWDO-522 always no repo verify

### DIFF
--- a/src/sc/clone/cloners/cloner_runner.py
+++ b/src/sc/clone/cloners/cloner_runner.py
@@ -69,6 +69,7 @@ class ClonerRunner:
             cache = project_config.effective_cache,
             repo_url = project_config.repo_url,
             repo_rev = project_config.repo_rev,
+            no_repo_verify = project_config.no_repo_verify
         )
 
         if rev := cli_overrides.get("rev"):
@@ -82,5 +83,8 @@ class ClonerRunner:
             logger.info(
                 f"Option [-m] override manifest with [{cli_overrides.get('manifest')}]")
             cloner_config.manifest = cli_overrides.get("manifest")
+        
+        if cli_overrides.get("verify"):
+            cloner_config.verify = True
 
         return cloner_config

--- a/src/sc/clone/cloners/repo_cloner.py
+++ b/src/sc/clone/cloners/repo_cloner.py
@@ -39,6 +39,7 @@ class RepoClonerConfig(BaseModel):
     cache: bool = True
     repo_url: str | None = None
     repo_rev: str | None = None
+    no_repo_verify: bool = False
     verify: bool = False
 
 class RepoCloner(Cloner):
@@ -94,8 +95,6 @@ class RepoCloner(Cloner):
         # If mirror is true we're creating a cache
         groups = "default,-notcached" if mirror else None
         
-        no_repo_verify = True if self.config.repo_url or self.config.repo_rev else False
-        
         ref_type = self._is_branch_tag_or_sha(self.config.uri, self.config.branch)
         
         if ref_type == RefType.TAG:
@@ -112,7 +111,7 @@ class RepoCloner(Cloner):
             reference = reference,
             groups = groups,
             repo_url = self.config.repo_url,
-            no_repo_verify = no_repo_verify,
+            no_repo_verify = self.config.no,
             repo_rev = self.config.repo_rev,
             verify=self.config.verify
         )

--- a/src/sc/clone/cloners/repo_cloner.py
+++ b/src/sc/clone/cloners/repo_cloner.py
@@ -94,8 +94,6 @@ class RepoCloner(Cloner):
         # If mirror is true we're creating a cache
         groups = "default,-notcached" if mirror else None
         
-        no_repo_verify = True if self.config.repo_url or self.config.repo_rev else False
-        
         ref_type = self._is_branch_tag_or_sha(self.config.uri, self.config.branch)
         
         if ref_type == RefType.TAG:
@@ -112,7 +110,7 @@ class RepoCloner(Cloner):
             reference = reference,
             groups = groups,
             repo_url = self.config.repo_url,
-            no_repo_verify = no_repo_verify,
+            no_repo_verify = True,
             repo_rev = self.config.repo_rev,
             verify=self.config.verify
         )

--- a/src/sc/clone/project_list/project_list.py
+++ b/src/sc/clone/project_list/project_list.py
@@ -27,6 +27,7 @@ class Project(BaseModel):
     cache: bool = True
     repo_url: str | None = None
     repo_rev: str | None = None
+    no_repo_verify: bool = False
     inherited: str | None = None
 
     @model_validator(mode='after')


### PR DESCRIPTION
Currently we have sc clone add --no-repo-verify if you provide repo_url or repo_rev. However with our current setup even without either of these we need --no-repo-verify as our repo entrypoint applies them anyway. Therefore we need to always apply no-repo-verify
