### PR TITLE
gh18 don't prepend branch prefix if provided

### DIFF
--- a/src/sc/branching/branching.py
+++ b/src/sc/branching/branching.py
@@ -166,6 +166,8 @@ def create_branch(
         name: str | None = None
     ) -> Branch:
     if name:
+        if name.startswith(f"{branch_type}/"):
+            name = name.split("/", 1)[1]
         return Branch(branch_type, name)
 
     if branch_type in {BranchType.DEVELOP, BranchType.MASTER}:

--- a/src/sc/branching/commands/init.py
+++ b/src/sc/branching/commands/init.py
@@ -25,7 +25,8 @@ from sc_manifest_parser import ProjectElementInterface, ScManifest
 @dataclass
 class Init(Command):
     def run_git_command(self):
-        GitFlowLibrary.init(self.top_dir)
+        if not GitFlowLibrary.is_gitflow_enabled(self.top_dir):
+            GitFlowLibrary.init(self.top_dir)
 
     def run_repo_command(self):
         Init.init_gitflow_for_manifest(self.top_dir)


### PR DESCRIPTION
Closes #18 

Don't prepend branch prefix if provided. Sneaky edit on not gitflow init on Init if already inited.