### PR TITLE
gh28 sc push failing

### DIFF
--- a/src/sc/branching/branching.py
+++ b/src/sc/branching/branching.py
@@ -73,7 +73,6 @@ class SCBranching:
         verify: bool = False,
         run_dir: Path = Path.cwd(),
     ):
-        logger.info(f"branch_type: {branch_type} name: {name}")
         top_dir, project_type = detect_project(run_dir)
         branch = create_branch(project_type, top_dir, branch_type, name)
         run_command_by_project_type(

--- a/src/sc/branching/commands/common.py
+++ b/src/sc/branching/commands/common.py
@@ -16,7 +16,7 @@ from ..branch import Branch, BranchType
 from sc_manifest_parser import ProjectElementInterface
 
 def get_alt_branch_name(branch: Branch, project: ProjectElementInterface) -> str | None:
-    match branch:
+    match branch.type:
         case BranchType.MASTER:
             return project.alternative_master
         case BranchType.DEVELOP:


### PR DESCRIPTION
SC push failing due to bad _remote_contains function. This function was checking if the sha is contained anywhere on the remote. This means pushing once worked fine but pushing a feature branch, finishing it, and then pushing develop wouldn't push the branch to develop due to the sha existing on a feature branch.

Closes #28 
Closes #16 