### PR TITLE
gh30 push write wrong rev

### DIFF
--- a/src/sc/branching/branch.py
+++ b/src/sc/branching/branch.py
@@ -27,6 +27,14 @@ class BranchType(str, Enum):
     def __str__(self):
         return self.value
 
+    @staticmethod
+    def is_valid(value: str) -> bool:
+        try:
+            BranchType(value)
+            return True
+        except ValueError:
+            return False
+
 @dataclass
 class Branch:
     type: BranchType

--- a/src/sc/branching/branching.py
+++ b/src/sc/branching/branching.py
@@ -39,6 +39,7 @@ from .exceptions import ScInitError
 logger = logging.getLogger(__name__)
 
 class ProjectType(Enum):
+    """Git or repo."""
     GIT = "git"
     REPO = "repo"
 
@@ -133,14 +134,10 @@ class SCBranching:
     ):
         top_dir, project_type = detect_project(run_dir)
         branch = create_branch(project_type, top_dir, branch_type, name)
-        try:
-            run_command_by_project_type(
-                Finish(top_dir, branch, base),
-                project_type
-            )
-        except FinishOperationError as e:
-            logger.error(e)
-            sys.exit(1)
+        run_command_by_project_type(
+            Finish(top_dir, branch, base),
+            project_type
+        )
 
     @staticmethod
     def list(branch_type: BranchType, run_dir: Path = Path.cwd()):

--- a/src/sc/branching/branching.py
+++ b/src/sc/branching/branching.py
@@ -25,7 +25,7 @@ from .branch import Branch, BranchType
 from .commands.checkout import Checkout
 from .commands.clean import Clean
 from .commands.command import Command
-from .commands.finish import Finish, FinishOperationError
+from .commands.finish import Finish
 from .commands.init import Init
 from .commands.list import List
 from .commands.pull import Pull

--- a/src/sc/branching/commands/finish.py
+++ b/src/sc/branching/commands/finish.py
@@ -194,6 +194,7 @@ class Finish(Command):
 
         self._delete_tag_if_exists(manifest_repo, self.branch.suffix)
         rev_only_change_branches = self._get_rev_only_change_branches(base)
+        print(rev_only_change_branches)
 
         try:
             GitFlowLibrary.finish(
@@ -207,35 +208,7 @@ class Finish(Command):
             logger.warning(
                 "Manifest finish failed. Attempting to auto resolve conflicts.")
 
-            while True:
-                if manifest_repo.active_branch.name not in rev_only_change_branches:
-                    logger.error(
-                        "Can't automatically resolve conflict! Resolve yourself and "
-                        f"rerun `sc {self.branch.type} finish {self.branch.suffix}`"
-                    )
-                    sys.exit(1)
-
-                rev_only_change_branches.pop(manifest_repo.active_branch.name)
-
-                for path in manifest_repo.index.unmerged_blobs().keys():
-                    manifest_repo.git.checkout("--ours", path)
-                    manifest_repo.git.add(".")
-                manifest_repo.git.commit("-m", "Automatic conflict resolution.")
-
-                try:
-                    GitFlowLibrary.finish(
-                        manifest_dir,
-                        self.branch.type,
-                        name=self.branch.suffix,
-                        keep=True,
-                        tag_message=self._tag_msg
-                    )
-                    # Break on successful finish.
-                    break
-                except subprocess.CalledProcessError:
-                    # Loop to next branch or failure.
-                    continue
-
+            self._auto_resolve_manifest_conflicts(manifest_repo, rev_only_change_branches)
 
     def _rebase_manifest(self, base: str | None):
         """Rewrites the manifest with any newer commits pulled on top.
@@ -321,29 +294,74 @@ class Finish(Command):
             logger.info("Run sc develop push to push to remote!")
         elif self.branch.type == BranchType.HOTFIX:
             base_prefix, base_name = base.split('/', 1)
-            logger.info(f"Run sc {base_prefix} push {base_prefix} to push to remote!")
+            logger.info(f"Run sc {base_prefix} push to push to remote!")
+
+    def _auto_resolve_manifest_conflicts(
+            self,
+            manifest_repo: Repo,
+            rev_only_change_branches: list[str]
+        ):
+        while True:
+            if not self._has_merge_conflicts(manifest_repo):
+                # TODO: Better error message
+                logger.error(
+                    "Can't automatically resolve conflict as some other error "
+                    "has occured!"
+                )
+
+            if manifest_repo.active_branch.name not in rev_only_change_branches:
+                logger.error(
+                    "Can't automatically resolve conflict! Resolve yourself and "
+                    f"rerun `sc {self.branch.type} finish {self.branch.suffix}`"
+                )
+                sys.exit(1)
+
+            print(manifest_repo.active_branch.name)
+            rev_only_change_branches.remove(manifest_repo.active_branch.name)
+
+            for path in manifest_repo.index.unmerged_blobs().keys():
+                print(path)
+                manifest_repo.git.checkout("--ours", path)
+            manifest_repo.git.commit("-am", "Automatic conflict resolution.")
+
+            try:
+                GitFlowLibrary.finish(
+                    manifest_repo.working_dir,
+                    self.branch.type,
+                    name=self.branch.suffix,
+                    keep=True,
+                    tag_message=self._tag_msg
+                )
+                # Break on successful finish.
+                break
+            except subprocess.CalledProcessError:
+                # Loop to next branch or failure.
+                continue
 
     def _get_rev_only_change_branches(self, base: str | None) -> list[str]:
-        rev_only_change_branches = []
         manifest = ScManifest.from_repo_root(self.top_dir / ".repo")
-        if self.branch.type == BranchType.RELEASE:
-            dev_manifest = self._get_branches_manifest("develop")
-            if manifest.equals_ignoring_revisions(dev_manifest):
-                rev_only_change_branches.append("develop")
-            master_manifest = self._get_branches_manifest("master")
-            if manifest.equals_ignoring_revisions("master"):
-                rev_only_change_branches.append("master")
-        elif self.branch.type == BranchType.FEATURE:
-            dev_manifest = self._get_branches_manifest("develop")
-            if manifest.equals_ignoring_revisions(dev_manifest):
-                rev_only_change_branches.append("develop")
-        elif self.branch.type == BranchType.HOTFIX:
-            base_manifest = self._get_branches_manifest(base)
-            if manifest.equals_ignoring_revisions(base_manifest):
-                rev_only_change_branches.append(base)
+        branches: list[str] = []
 
-        return rev_only_change_branches
+        def check(branch_name: str | None):
+            if not branch_name:
+                return
+            other = self._get_branches_manifest(branch_name)
+            if manifest.equals(other, ignore_attrs={"revision"}):
+                branches.append(branch_name)
 
+        match self.branch.type:
+            case BranchType.RELEASE:
+                check("develop")
+                check("master")
+            case BranchType.FEATURE:
+                check("develop")
+            case BranchType.HOTFIX:
+                check(base)
+
+        return branches
+
+    def _has_merge_conflicts(self, repo: Repo):
+        return bool(repo.index.unmerged_blobs())
 
     def _get_branches_manifest(self, branch: str) -> ScManifest:
         """Get the ScManifest of a particular branch."""

--- a/src/sc/branching/commands/finish.py
+++ b/src/sc/branching/commands/finish.py
@@ -69,15 +69,41 @@ class Finish(Command):
             sys.exit(1)
 
     def run_repo_command(self):
-        """Runs gitflow finish in all non locked manifest projects, then
-        runs gitflow finish in the manifest repository and finally updates
-        the manifest with the new commit shas.
+        """
+        Finish all projects defined in the manifest using git-flow semantics.
+
+        Process:
+        1. For each project listed in the manifest, run `git flow finish`.
+        - If merge conflicts occur, they must be resolved manually before continuing.
+
+        2. After all projects are finished, run `git flow finish` on the manifest repository.
+        - If a merge conflict occurs in the manifest and the only differences are
+            project revision changes, the conflict is auto-resolved.
+        - This is safe because any functional conflicts between those revisions
+            were already resolved when finishing the individual projects.
+
+        3. Once the manifest is merged, pull all projects to update them to the
+        latest revisions referenced by the manifest.
+
+        4. Create an additional commit on the target branch of the manifest to
+        update all project revision references to their latest state.
+
+        Result:
+        All projects and the manifest are merged consistently, and the manifest
+        reflects the final resolved revisions of every project.
         """
         self._error_on_sc_uninitialised()
 
         if not self._branch_exists_locally_in_manifest(self.branch.name):
             logger.error(
                 f"Branch {self.branch.name} doesn't exist so can't be finished!")
+            sys.exit(1)
+
+        if self.branch.type not in {BranchType.FEATURE, BranchType.HOTFIX, BranchType.RELEASE}:
+            logger.error(
+                f"Can't finish branch of type {self.branch.type}! "
+                "Can only finish release, feature or hotfix branches."
+            )
             sys.exit(1)
 
         if self.branch.type == BranchType.HOTFIX:

--- a/src/sc/branching/commands/finish.py
+++ b/src/sc/branching/commands/finish.py
@@ -142,15 +142,23 @@ class Finish(Command):
         """
         manifest = ScManifest.from_repo_root(self.top_dir / '.repo')
         for proj in manifest.projects:
-            if proj.lock_status is not None:
-                continue
             proj_dir = self.top_dir / proj.path
             logger.info(f"Operating on {proj_dir}")
             proj_repo = Repo(proj_dir)
+
+            if proj.lock_status == "READ_ONLY":
+                continue
+
+            self._delete_tag_if_exists(proj_repo, self.branch.suffix)
+            if proj.lock_status == "TAG_ONLY":
+                logger.info(f"Project {proj_dir} is TAG_ONLY")
+                if self.branch.type in {BranchType.HOTFIX, BranchType.RELEASE}:
+                    proj_repo.git.tag(self.branch.suffix)
+                continue
+
             if base:
                 self._set_branch_base(base, proj_dir, proj.remote)
 
-            self._delete_tag_if_exists(proj_repo, self.branch.suffix)
             try:
                 GitFlowLibrary.finish(
                     proj_dir,

--- a/src/sc/branching/commands/finish.py
+++ b/src/sc/branching/commands/finish.py
@@ -193,7 +193,7 @@ class Finish(Command):
             self._set_branch_base(base, manifest_dir)
 
         self._delete_tag_if_exists(Repo(manifest_dir), self.branch.suffix)
-        rev_only_change_branches = self._get_rev_only_change_branches(base)
+        rev_only_change_branches = self._get_branches_with_revision_only_diff(base)
 
         try:
             GitFlowLibrary.finish(
@@ -346,7 +346,18 @@ class Finish(Command):
                 # Loop to next branch or failure.
                 continue
 
-    def _get_rev_only_change_branches(self, base: str | None) -> list[str]:
+    def _get_branches_with_revision_only_diff(self, base: str | None) -> list[str]:
+        """Get a list of target manifest branches that differ only by revisions.
+            These branches are then able to be auto resolved if there is a conflict.
+
+        Args:
+            base (str | None): The base if finishing a hotfix branch.
+
+        Returns:
+            list[str]: A list of relevant branches which manifest differs from the
+                starting manifest by revision only.
+
+        """
         manifest = ScManifest.from_repo_root(self.top_dir / ".repo")
         branches: list[str] = []
 

--- a/src/sc/branching/commands/finish.py
+++ b/src/sc/branching/commands/finish.py
@@ -176,10 +176,10 @@ class Finish(Command):
 
     def _delete_tag_if_exists(self, repo: Repo, tag: str):
         try:
-            logger.info(f"Attempt deleting tag: {tag}")
             repo.git.tag('-d', tag)
+            logger.info(f"Deleted preexisting tag {tag}")
         except GitCommandError:
-            logger.info(f"Tag doesn't exist.")
+            pass
 
     def _finish_manifest_repo(self, base: str | None):
         """Run gitflow finish on the manifest repository.
@@ -188,13 +188,11 @@ class Finish(Command):
             base (str | None): Set the base branch if provided.
         """
         manifest_dir = self.top_dir / ".repo" / "manifests"
-        manifest_repo = Repo(manifest_dir)
         if base:
             self._set_branch_base(base, manifest_dir)
 
-        self._delete_tag_if_exists(manifest_repo, self.branch.suffix)
+        self._delete_tag_if_exists(Repo(manifest_dir), self.branch.suffix)
         rev_only_change_branches = self._get_rev_only_change_branches(base)
-        print(rev_only_change_branches)
 
         try:
             GitFlowLibrary.finish(
@@ -208,7 +206,7 @@ class Finish(Command):
             logger.warning(
                 "Manifest finish failed. Attempting to auto resolve conflicts.")
 
-            self._auto_resolve_manifest_conflicts(manifest_repo, rev_only_change_branches)
+            self._auto_resolve_manifest_conflicts(rev_only_change_branches)
 
     def _rebase_manifest(self, base: str | None):
         """Rewrites the manifest with any newer commits pulled on top.
@@ -241,7 +239,7 @@ class Finish(Command):
         Repo(self.top_dir / '.repo' / 'manifests').git.switch('master')
         manifest = ScManifest.from_repo_root(self.top_dir / '.repo')
         for proj in manifest.projects:
-            if proj.lock_status == None:
+            if proj.lock_status is None:
                 master = GitFlowLibrary.get_master_branch(self.top_dir / proj.path)
                 self._rebase_proj(self.top_dir / proj.path, master)
 
@@ -252,7 +250,7 @@ class Finish(Command):
         Repo(self.top_dir / '.repo' / 'manifests').git.switch(base)
         manifest = ScManifest.from_repo_root(self.top_dir / '.repo')
         for proj in manifest.projects:
-            if proj.lock_status == None:
+            if proj.lock_status is None:
                 self._rebase_proj(self.top_dir / proj.path, base)
 
         self._update_manifest(manifest)
@@ -272,7 +270,7 @@ class Finish(Command):
 
     def _update_manifest(self, manifest: ScManifest):
         for proj in manifest.projects:
-            if proj.lock_status == None:
+            if proj.lock_status is None:
                 proj_repo = Repo(self.top_dir / proj.path)
                 proj.revision = proj_repo.head.commit.hexsha
 
@@ -293,21 +291,32 @@ class Finish(Command):
         elif self.branch.type == BranchType.FEATURE:
             logger.info("Run sc develop push to push to remote!")
         elif self.branch.type == BranchType.HOTFIX:
-            base_prefix, base_name = base.split('/', 1)
+            if "/" in base:
+                base_prefix, base_name = base.split('/', 1)
+            else:
+                base_prefix = base
             logger.info(f"Run sc {base_prefix} push to push to remote!")
 
     def _auto_resolve_manifest_conflicts(
             self,
-            manifest_repo: Repo,
             rev_only_change_branches: list[str]
         ):
+        """
+        Resolve manifest merge conflict automatically if only project revisions have
+        changed between them.
+
+        Args:
+            rev_only_change_branches (list[str]): A list of target branches that have
+                changes in only the revisions.
+        """
+        manifest_repo = Repo(self.top_dir / ".repo" / 'manifests')
         while True:
             if not self._has_merge_conflicts(manifest_repo):
-                # TODO: Better error message
                 logger.error(
-                    "Can't automatically resolve conflict as some other error "
-                    "has occured!"
+                    "Finish failed but no merge conflicts were detected in the manifest "
+                    "repository. Manual intervention required."
                 )
+                sys.exit(1)
 
             if manifest_repo.active_branch.name not in rev_only_change_branches:
                 logger.error(
@@ -316,11 +325,9 @@ class Finish(Command):
                 )
                 sys.exit(1)
 
-            print(manifest_repo.active_branch.name)
             rev_only_change_branches.remove(manifest_repo.active_branch.name)
 
             for path in manifest_repo.index.unmerged_blobs().keys():
-                print(path)
                 manifest_repo.git.checkout("--ours", path)
             manifest_repo.git.commit("-am", "Automatic conflict resolution.")
 
@@ -367,8 +374,10 @@ class Finish(Command):
         """Get the ScManifest of a particular branch."""
         manifest_repo = Repo(self.top_dir / ".repo" / "manifests")
         start_branch = manifest_repo.active_branch.name
-        manifest_repo.git.switch(branch)
-        manifest = ScManifest.from_repo_root(self.top_dir / ".repo")
-        manifest_repo.git.switch(start_branch)
+        try:
+            manifest_repo.git.switch(branch)
+            manifest = ScManifest.from_repo_root(self.top_dir / ".repo")
+        finally:
+            manifest_repo.git.switch(start_branch)
         return manifest
 

--- a/src/sc/branching/commands/finish.py
+++ b/src/sc/branching/commands/finish.py
@@ -66,6 +66,7 @@ class Finish(Command):
             )
         except subprocess.CalledProcessError:
             logger.error("Git flow finish failed!")
+            sys.exit(1)
 
     def run_repo_command(self):
         """Runs gitflow finish in all non locked manifest projects, then
@@ -161,7 +162,7 @@ class Finish(Command):
             except subprocess.CalledProcessError:
                 logger.error(
                     f"Finish failed in {proj_dir}, resolve errors and rerun "
-                    f"`sc {self.branch.type} release {self.branch.suffix}`"
+                    f"`sc {self.branch.type} finish {self.branch.suffix}`"
                 )
                 sys.exit(1)
 
@@ -264,7 +265,7 @@ class Finish(Command):
         except subprocess.CalledProcessError:
             logger.error(
                 f"Rebase failed in {proj_path}, please resolve above error and rerun "
-                f"`sc {self.branch.type} release {self.branch.suffix}`"
+                f"`sc {self.branch.type} finish {self.branch.suffix}`"
             )
             sys.exit(1)
 

--- a/src/sc/branching/commands/finish.py
+++ b/src/sc/branching/commands/finish.py
@@ -14,6 +14,7 @@
 
 from dataclasses import dataclass
 import logging
+import os
 from pathlib import Path
 import subprocess
 import sys
@@ -29,13 +30,6 @@ from sc_manifest_parser import ScManifest
 
 logger = logging.getLogger(__name__)
 
-class FinishOperationError(RuntimeError):
-    def __init__(self, path: str | Path, message: str):
-        super().__init__(
-            f"Finish failed in {path}: {message} \n"
-            "Please resolve error and rerun sc finish."
-        )
-
 @dataclass
 class Finish(Command):
     branch: Branch
@@ -47,9 +41,6 @@ class Finish(Command):
 
     def run_git_command(self):
         """Runs gitflow finish in the git project.
-
-        Raises:
-            FinishOperationError: If the project fails to finish
         """
         if self.branch.type == BranchType.HOTFIX:
             base = self._resolve_base(self.top_dir)
@@ -74,15 +65,12 @@ class Finish(Command):
                 tag_message=self._tag_msg
             )
         except subprocess.CalledProcessError:
-            raise FinishOperationError(self.top_dir, "Check above for error.")
+            logger.error("Git flow finish failed!")
 
     def run_repo_command(self):
         """Runs gitflow finish in all non locked manifest projects, then
         runs gitflow finish in the manifest repository and finally updates
         the manifest with the new commit shas.
-
-        Raises:
-            FinishOperationError: If any project fails to finish.
         """
         self._error_on_sc_uninitialised()
 
@@ -108,6 +96,7 @@ class Finish(Command):
         if self.branch.type in {BranchType.HOTFIX, BranchType.RELEASE}:
             self._tag_msg = self._prompt_tag_msg()
 
+        self._stop_commit_msg_popup()
         self._finish_all_projects(base)
         self._finish_manifest_repo(base)
 
@@ -140,14 +129,15 @@ class Finish(Command):
                 return msg
             logger.warning("Cannot provide an empty tag message!")
 
+    def _stop_commit_msg_popup(self):
+        """Stops every merge confirming commit message."""
+        os.environ["GIT_MERGE_AUTOEDIT"] = "no"
+
     def _finish_all_projects(self, base: str | None):
         """Run gitflow finish in all non-locked projects.
 
         Args:
             base (str | None): Sets the base for each project if provided.
-
-        Raises:
-            FinishOperationError: If any project fails to finish.
         """
         manifest = ScManifest.from_repo_root(self.top_dir / '.repo')
         for proj in manifest.projects:
@@ -157,10 +147,7 @@ class Finish(Command):
             logger.info(f"Operating on {proj_dir}")
             proj_repo = Repo(proj_dir)
             if base:
-                try:
-                    self._set_branch_base(base, proj.path, proj.remote)
-                except ValueError as e:
-                    raise FinishOperationError(proj.path, e)
+                self._set_branch_base(base, proj_dir, proj.remote)
 
             self._delete_tag_if_exists(proj_repo, self.branch.suffix)
             try:
@@ -172,11 +159,19 @@ class Finish(Command):
                     tag_message=self._tag_msg
                 )
             except subprocess.CalledProcessError:
-                raise FinishOperationError(proj.path, "Check above for error.")
+                logger.error(
+                    f"Finish failed in {proj_dir}, resolve errors and rerun "
+                    f"`sc {self.branch.type} release {self.branch.suffix}`"
+                )
+                sys.exit(1)
 
     def _set_branch_base(self, base: str, directory: str | Path, remote: str = "origin"):
         if not self._branch_exists(base, directory, remote):
-            raise ValueError(f"Base branch '{base}' not found locally or on {remote}.")
+            logger.error(
+                f"Base branch '{base}' not found locally or on remote '{remote}' "
+                f"in {directory}."
+            )
+            sys.exit(1)
         GitFlowLibrary.set_branch_base(self.branch.name, base, directory)
 
     def _delete_tag_if_exists(self, repo: Repo, tag: str):
@@ -192,66 +187,123 @@ class Finish(Command):
         Args:
             base (str | None): Set the base branch if provided.
         """
+        manifest_dir = self.top_dir / ".repo" / "manifests"
+        manifest_repo = Repo(manifest_dir)
         if base:
-            try:
-                self._set_branch_base(base, self.top_dir / '.repo' / 'manifests')
-            except ValueError as e:
-                raise FinishOperationError(self.top_dir / '.repo' / 'manifests', e)
-        self._delete_tag_if_exists(
-            Repo(self.top_dir / '.repo' / 'manifests'), self.branch.suffix)
+            self._set_branch_base(base, manifest_dir)
+
+        self._delete_tag_if_exists(manifest_repo, self.branch.suffix)
+        rev_only_change_branches = self._get_rev_only_change_branches(base)
+
         try:
             GitFlowLibrary.finish(
-                self.top_dir / '.repo' / 'manifests',
+                manifest_dir,
                 self.branch.type,
                 name=self.branch.suffix,
                 keep=True,
                 tag_message=self._tag_msg
             )
         except subprocess.CalledProcessError:
-            raise FinishOperationError(
-                self.top_dir / '.repo' / 'manifests', "Check above for error.")
+            logger.warning(
+                "Manifest finish failed. Attempting to auto resolve conflicts.")
+
+            while True:
+                if manifest_repo.active_branch.name not in rev_only_change_branches:
+                    logger.error(
+                        "Can't automatically resolve conflict! Resolve yourself and "
+                        f"rerun `sc {self.branch.type} finish {self.branch.suffix}`"
+                    )
+                    sys.exit(1)
+
+                rev_only_change_branches.pop(manifest_repo.active_branch.name)
+
+                for path in manifest_repo.index.unmerged_blobs().keys():
+                    manifest_repo.git.checkout("--ours", path)
+                    manifest_repo.git.add(".")
+                manifest_repo.git.commit("-m", "Automatic conflict resolution.")
+
+                try:
+                    GitFlowLibrary.finish(
+                        manifest_dir,
+                        self.branch.type,
+                        name=self.branch.suffix,
+                        keep=True,
+                        tag_message=self._tag_msg
+                    )
+                    # Break on successful finish.
+                    break
+                except subprocess.CalledProcessError:
+                    # Loop to next branch or failure.
+                    continue
+
 
     def _rebase_manifest(self, base: str | None):
-        """R
+        """Rewrites the manifest with any newer commits pulled on top.
 
         Args:
-            base (str | None): _description_
+            base (str | None): The base a hotfix branch should be merged into.
         """
         if self.branch.type == BranchType.FEATURE:
-            self._rebase_to_develop()
+            self._rebase_develop()
 
         elif self.branch.type == BranchType.RELEASE:
-            self._rebase_to_master()
-            self._rebase_to_develop()
+            self._rebase_master()
+            self._rebase_develop()
 
         elif self.branch.type == BranchType.HOTFIX:
-            self._rebase_to_base(base)
+            self._rebase_base(base)
 
-    def _rebase_to_develop(self):
+    def _rebase_develop(self):
         Repo(self.top_dir / '.repo' / 'manifests').git.switch('develop')
         manifest = ScManifest.from_repo_root(self.top_dir / '.repo')
         for proj in manifest.projects:
             if proj.lock_status is None:
                 develop = GitFlowLibrary.get_develop_branch(self.top_dir / proj.path)
-                Repo(self.top_dir / proj.path).git.switch(develop)
+                self._rebase_proj(self.top_dir / proj.path, develop)
+
+        self._update_manifest(manifest)
         self._commit_manifest("develop")
 
-    def _rebase_to_master(self):
+    def _rebase_master(self):
         Repo(self.top_dir / '.repo' / 'manifests').git.switch('master')
         manifest = ScManifest.from_repo_root(self.top_dir / '.repo')
         for proj in manifest.projects:
             if proj.lock_status == None:
                 master = GitFlowLibrary.get_master_branch(self.top_dir / proj.path)
-                Repo(self.top_dir / proj.path).git.switch(master)
+                self._rebase_proj(self.top_dir / proj.path, master)
+
+        self._update_manifest(manifest)
         self._commit_manifest("master")
 
-    def _rebase_to_base(self, base: str | None):
+    def _rebase_base(self, base: str | None):
         Repo(self.top_dir / '.repo' / 'manifests').git.switch(base)
         manifest = ScManifest.from_repo_root(self.top_dir / '.repo')
         for proj in manifest.projects:
             if proj.lock_status == None:
-                Repo(self.top_dir / proj.path).git.switch(base)
+                self._rebase_proj(self.top_dir / proj.path, base)
+
+        self._update_manifest(manifest)
         self._commit_manifest(base)
+
+    def _rebase_proj(self, proj_path: Path, branch: str):
+        proj_repo = Repo(proj_path)
+        proj_repo.git.switch(branch)
+        try:
+            subprocess.run(["git", "pull"], cwd=proj_path, check=True)
+        except subprocess.CalledProcessError:
+            logger.error(
+                f"Rebase failed in {proj_path}, please resolve above error and rerun "
+                f"`sc {self.branch.type} release {self.branch.suffix}`"
+            )
+            sys.exit(1)
+
+    def _update_manifest(self, manifest: ScManifest):
+        for proj in manifest.projects:
+            if proj.lock_status == None:
+                proj_repo = Repo(self.top_dir / proj.path)
+                proj.revision = proj_repo.head.commit.hexsha
+
+        manifest.write()
 
     def _commit_manifest(self, branch: str):
         manifest_repo = Repo(self.top_dir / '.repo' / 'manifests')
@@ -270,3 +322,35 @@ class Finish(Command):
         elif self.branch.type == BranchType.HOTFIX:
             base_prefix, base_name = base.split('/', 1)
             logger.info(f"Run sc {base_prefix} push {base_prefix} to push to remote!")
+
+    def _get_rev_only_change_branches(self, base: str | None) -> list[str]:
+        rev_only_change_branches = []
+        manifest = ScManifest.from_repo_root(self.top_dir / ".repo")
+        if self.branch.type == BranchType.RELEASE:
+            dev_manifest = self._get_branches_manifest("develop")
+            if manifest.equals_ignoring_revisions(dev_manifest):
+                rev_only_change_branches.append("develop")
+            master_manifest = self._get_branches_manifest("master")
+            if manifest.equals_ignoring_revisions("master"):
+                rev_only_change_branches.append("master")
+        elif self.branch.type == BranchType.FEATURE:
+            dev_manifest = self._get_branches_manifest("develop")
+            if manifest.equals_ignoring_revisions(dev_manifest):
+                rev_only_change_branches.append("develop")
+        elif self.branch.type == BranchType.HOTFIX:
+            base_manifest = self._get_branches_manifest(base)
+            if manifest.equals_ignoring_revisions(base_manifest):
+                rev_only_change_branches.append(base)
+
+        return rev_only_change_branches
+
+
+    def _get_branches_manifest(self, branch: str) -> ScManifest:
+        """Get the ScManifest of a particular branch."""
+        manifest_repo = Repo(self.top_dir / ".repo" / "manifests")
+        start_branch = manifest_repo.active_branch.name
+        manifest_repo.git.switch(branch)
+        manifest = ScManifest.from_repo_root(self.top_dir / ".repo")
+        manifest_repo.git.switch(start_branch)
+        return manifest
+

--- a/src/sc/branching/commands/finish.py
+++ b/src/sc/branching/commands/finish.py
@@ -99,13 +99,6 @@ class Finish(Command):
                 f"Branch {self.branch.name} doesn't exist so can't be finished!")
             sys.exit(1)
 
-        if self.branch.type not in {BranchType.FEATURE, BranchType.HOTFIX, BranchType.RELEASE}:
-            logger.error(
-                f"Can't finish branch of type {self.branch.type}! "
-                "Can only finish release, feature or hotfix branches."
-            )
-            sys.exit(1)
-
         if self.branch.type == BranchType.HOTFIX:
             base = self._resolve_base(self.top_dir / '.repo' / 'manifests')
             if not base:
@@ -118,7 +111,7 @@ class Finish(Command):
             base = None
 
         if RepoLibrary.get_manifest_branch(self.top_dir) != self.branch.name:
-            Checkout(self.top_dir, self.branch)
+            Checkout(self.top_dir, self.branch).run_repo_command()
 
         if self.branch.type in {BranchType.HOTFIX, BranchType.RELEASE}:
             self._tag_msg = self._prompt_tag_msg()
@@ -335,7 +328,7 @@ class Finish(Command):
     def _auto_resolve_manifest_conflicts(
             self,
             rev_only_change_branches: list[str]
-        ):
+    ):
         """
         Resolve manifest merge conflict automatically if only project revisions have
         changed between them.

--- a/src/sc/branching/commands/push.py
+++ b/src/sc/branching/commands/push.py
@@ -118,7 +118,8 @@ class Push(Command):
     def _update_manifest_revisions(self, manifest: ScManifest):
         for proj in manifest.projects:
             proj_repo = Repo(self.top_dir / proj.path)
-            proj.revision = proj_repo.head.commit.hexsha
+            proj_branch_name = common.resolve_project_branch_name(self.branch, proj)
+            proj.revision = proj_repo.branches[proj_branch_name].commit.hexsha
         manifest.write()
 
     def _push_manifest(self, msg: str):
@@ -127,3 +128,4 @@ class Push(Command):
         if manifest_repo.is_dirty():
             manifest_repo.git.commit("-m", msg)
         manifest_repo.git.push("-u", "origin", self.branch.name)
+        manifest_repo.git.push("origin", "--tags")

--- a/src/sc/branching/commands/push.py
+++ b/src/sc/branching/commands/push.py
@@ -15,11 +15,12 @@
 from dataclasses import dataclass
 import logging
 import subprocess
+import sys
 
-from git import GitCommandError, Repo
+from git import Repo
 
 from . import common
-from ..branch import Branch
+from ..branch import Branch, BranchType
 from .checkout import Checkout
 from .command import Command
 from repo_library import RepoLibrary
@@ -39,22 +40,41 @@ class Push(Command):
     def run_repo_command(self):
         self._error_on_sc_uninitialised()
 
-        orig_manifest_branch = RepoLibrary.get_manifest_branch(self.top_dir)
+        orig_manifest_branch = self._get_original_branch()
 
         logger.info(f"Pushing branch {self.branch.name}")
 
         try:
             if RepoLibrary.get_manifest_branch(self.top_dir) != self.branch.name:
-                Checkout(self.top_dir, self.branch)
+                Checkout(self.top_dir, self.branch).run_repo_command()
             manifest = ScManifest.from_repo_root(self.top_dir / '.repo')
             self._push_projects(manifest.projects)
             self._update_manifest_revisions(manifest)
             self._push_manifest()
         finally:
             if RepoLibrary.get_manifest_branch(self.top_dir) != orig_manifest_branch:
-                Checkout(self.top_dir, orig_manifest_branch)
+                Checkout(self.top_dir, orig_manifest_branch).run_repo_command()
 
         logger.info(f"Push {self.branch.name} completed!")
+
+    def _get_original_branch(self) -> Branch:
+        orig_manifest_branch = RepoLibrary.get_manifest_branch(self.top_dir)
+
+        if orig_manifest_branch == "develop":
+            return Branch(BranchType.DEVELOP)
+        elif orig_manifest_branch == "master":
+            return Branch(BranchType.MASTER)
+
+        if "/" in orig_manifest_branch:
+            prefix, name = orig_manifest_branch.split("/", 1)
+            if BranchType.is_valid(prefix):
+                return Branch(BranchType(prefix), name)
+
+        logger.error(
+            f"Original manifest branch {orig_manifest_branch} is not a "
+            "valid sc branch. Please checkout a valid sc branch to push."
+        )
+        sys.exit(1)
 
     def _push_projects(self, projects: list[ProjectElementInterface]):
         for project in projects:

--- a/src/sc/branching/commands/push.py
+++ b/src/sc/branching/commands/push.py
@@ -106,11 +106,21 @@ class Push(Command):
     def _do_push_project(self, proj: ProjectElementInterface):
         proj_repo = Repo(self.top_dir / proj.path)
         proj_branch_name = common.resolve_project_branch_name(self.branch, proj)
-        subprocess.run(
-            ["git", "push", "-u", proj.remote, proj_branch_name],
-            cwd=proj_repo.working_dir
-        )
-        subprocess.run(["git", "push", proj.remote, "--tags"], cwd=proj_repo.working_dir)
+        try:
+            subprocess.run(
+                ["git", "push", "-u", proj.remote, proj_branch_name],
+                cwd=proj_repo.working_dir,
+                check=True
+            )
+            subprocess.run(
+                ["git", "push", proj.remote, "--tags"],
+                cwd=proj_repo.working_dir,
+                check=True
+            )
+        except subprocess.CalledProcessError:
+            logger.error(
+                f"Failed to push project {proj_repo.working_dir}. Resolve error and "
+                "rerun.")
 
     def _do_push_tag_only_project(self, proj: ProjectElementInterface):
         proj_repo = Repo(self.top_dir / proj.path)
@@ -138,15 +148,29 @@ class Push(Command):
         manifest_repo = Repo(self.top_dir / '.repo' / 'manifests')
         manifest_repo.git.add(A=True)
         if manifest_repo.is_dirty():
+            try:
+                subprocess.run(
+                    ["git", "commit"],
+                    cwd=self.top_dir / ".repo" / "manifests",
+                    check=True
+                )
+            except subprocess.CalledProcessError:
+                logger.error(
+                    "Failed to commit manifest. Please check error and rerun " \
+                    "push."
+                )
+                sys.exit(1)
+        try:
             subprocess.run(
-                ["git", "commit"],
-                cwd=self.top_dir / ".repo" / "manifests"
+                ["git", "push", "-u", "origin", self.branch.name],
+                cwd=self.top_dir / ".repo" / "manifests",
+                check=True
             )
-        subprocess.run(
-            ["git", "push", "-u", "origin", self.branch.name],
-            cwd=self.top_dir / ".repo" / "manifests"
-        )
-        subprocess.run(
-            ["git", "push", "origin", "--tags"],
-            cwd=self.top_dir / ".repo" / "manifests"
-        )
+            subprocess.run(
+                ["git", "push", "origin", "--tags"],
+                cwd=self.top_dir / ".repo" / "manifests",
+                check=True
+            )
+        except subprocess.CalledProcessError:
+            logger.error("Failed to push manifest! Resolve errors and push again.")
+            sys.exit(1)

--- a/src/sc/branching/commands/push.py
+++ b/src/sc/branching/commands/push.py
@@ -120,7 +120,9 @@ class Push(Command):
         except subprocess.CalledProcessError:
             logger.error(
                 f"Failed to push project {proj_repo.working_dir}. Resolve error and "
-                "rerun.")
+                "rerun."
+            )
+            sys.exit(1)
 
     def _do_push_tag_only_project(self, proj: ProjectElementInterface):
         proj_repo = Repo(self.top_dir / proj.path)
@@ -156,7 +158,7 @@ class Push(Command):
                 )
             except subprocess.CalledProcessError:
                 logger.error(
-                    "Failed to commit manifest. Please check error and rerun " \
+                    "Failed to commit manifest. Please check error and rerun "
                     "push."
                 )
                 sys.exit(1)

--- a/src/sc/branching/commands/push.py
+++ b/src/sc/branching/commands/push.py
@@ -124,5 +124,11 @@ class Push(Command):
         manifest_repo.git.add(A=True)
         if manifest_repo.is_dirty():
             manifest_repo.git.commit("-m", msg)
-        manifest_repo.git.push("-u", "origin", self.branch.name)
-        manifest_repo.git.push("origin", "--tags")
+        subprocess.run(
+            ["git", "push", "-u", "origin", self.branch.name],
+            cwd=self.top_dir / ".repo" / "manifests"
+        )
+        subprocess.run(
+            ["git", "push", "origin", "--tags"],
+            cwd=self.top_dir / ".repo" / "manifests"
+        )

--- a/src/sc/branching/commands/push.py
+++ b/src/sc/branching/commands/push.py
@@ -42,28 +42,19 @@ class Push(Command):
         orig_manifest_branch = RepoLibrary.get_manifest_branch(self.top_dir)
 
         logger.info(f"Pushing branch {self.branch.name}")
-        msg = self._input_commit_msg()
 
         try:
             if RepoLibrary.get_manifest_branch(self.top_dir) != self.branch.name:
                 Checkout(self.top_dir, self.branch)
-            self._switch_manifest_to_branch(self.branch.name)
             manifest = ScManifest.from_repo_root(self.top_dir / '.repo')
             self._push_projects(manifest.projects)
             self._update_manifest_revisions(manifest)
-            self._push_manifest(msg)
+            self._push_manifest()
         finally:
             if RepoLibrary.get_manifest_branch(self.top_dir) != orig_manifest_branch:
                 Checkout(self.top_dir, orig_manifest_branch)
 
         logger.info(f"Push {self.branch.name} completed!")
-
-    def _input_commit_msg(self):
-        while True:
-            msg = input("Input commit message for manifest: ")
-            if msg:
-                return msg
-            logger.warning("Cannot provide an empty commit message!")
 
     def _push_projects(self, projects: list[ProjectElementInterface]):
         for project in projects:
@@ -109,8 +100,12 @@ class Push(Command):
         return branch in [h.name for h in repo.heads]
 
     def _remote_branch_contains(self, repo: Repo, remote: str, branch: str) -> bool:
+        try:
+            remote_commit = repo.refs[f"{remote}/{branch}"]
+        except IndexError:
+            return False
+
         local_commit = repo.heads[branch].commit
-        remote_commit = repo.refs[f"{remote}/{branch}"]
         return repo.is_ancestor(local_commit, remote_commit)
 
     def _update_manifest_revisions(self, manifest: ScManifest):
@@ -119,11 +114,14 @@ class Push(Command):
             proj.revision = proj_repo.head.commit.hexsha
         manifest.write()
 
-    def _push_manifest(self, msg: str):
+    def _push_manifest(self):
         manifest_repo = Repo(self.top_dir / '.repo' / 'manifests')
         manifest_repo.git.add(A=True)
         if manifest_repo.is_dirty():
-            manifest_repo.git.commit("-m", msg)
+            subprocess.run(
+                ["git", "commit"],
+                cwd=self.top_dir / ".repo" / "manifests"
+            )
         subprocess.run(
             ["git", "push", "-u", "origin", self.branch.name],
             cwd=self.top_dir / ".repo" / "manifests"

--- a/src/sc/branching/commands/start.py
+++ b/src/sc/branching/commands/start.py
@@ -14,6 +14,7 @@
 
 from dataclasses import dataclass
 import logging
+import sys
 
 from git import Repo
 
@@ -46,6 +47,7 @@ class Start(Command):
         local_branches = [head.name for head in manifest_repo.heads]
         if self.branch.name in remote_branches or self.branch.name in local_branches:
             logger.error(f"Branch {self.branch.name} already exists and can't be started.")
+            sys.exit(1)
 
         if '/' in self.base:
             base_branch_type, base_name = self.base.split('/', 1)
@@ -66,4 +68,4 @@ class Start(Command):
 
         manifest_repo.git.checkout('-b', self.branch.name)
         manifest_repo.git.commit("--allow-empty", m=f"Starting {self.branch.name}")
-        manifest_repo.remote("origin").push(self.branch.name)
+        manifest_repo.git.push("-u", "origin", self.branch.name)

--- a/src/sc/branching/commands/start.py
+++ b/src/sc/branching/commands/start.py
@@ -43,11 +43,7 @@ class Start(Command):
         manifest_dir = self.top_dir / '.repo' / 'manifests'
 
         manifest_repo = Repo(manifest_dir)
-        remote_branches = [ref.name for ref in manifest_repo.remotes['origin'].refs]
-        local_branches = [head.name for head in manifest_repo.heads]
-        if self.branch.name in remote_branches or self.branch.name in local_branches:
-            logger.error(f"Branch {self.branch.name} already exists and can't be started.")
-            sys.exit(1)
+        self._error_if_branch_exists(manifest_repo)
 
         if '/' in self.base:
             base_branch_type, base_name = self.base.split('/', 1)
@@ -69,3 +65,18 @@ class Start(Command):
         manifest_repo.git.checkout('-b', self.branch.name)
         manifest_repo.git.commit("--allow-empty", m=f"Starting {self.branch.name}")
         manifest_repo.git.push("-u", "origin", self.branch.name)
+
+    def _error_if_branch_exists(self, manifest_repo: Repo):
+        remote_branches = [ref.name for ref in manifest_repo.remotes['origin'].refs]
+        local_branches = [head.name for head in manifest_repo.heads]
+        if f"origin/{self.branch.name}" in remote_branches:
+            logger.error(
+                f"Branch {self.branch.name} exists on the remote manifest repo "
+                "so cannot be started."
+            )
+            sys.exit(1)
+        elif self.branch.name in local_branches:
+            logger.error(
+                f"Branch {self.branch.name} already exists locally in the manifest "
+                "repo so cannot be started.")
+            sys.exit(1)


### PR DESCRIPTION
This should have been a couple of PRs but is now all in one. The things changed are:

- Finish auto resolves manifests with only changes to revisions.
- Push checks out branch on all projects instead of switching manifest.
- Finish stops spamming messages to change merge commit messages.
- Start checks correctly for existing remote branch existing.
- Some other more general changes.