### PR TITLE
BWDO-524 update help screen

### DIFF
--- a/src/sc/branching_cli.py
+++ b/src/sc/branching_cli.py
@@ -25,40 +25,6 @@ logger = logging.getLogger(__name__)
 def cli():
     pass
 
-@cli.command()
-def init():
-    """Initialise for branching commands."""
-    SCBranching.init()
-
-@cli.command()
-def clean():
-    """Clean all modules. (git clean -fdx)."""
-    SCBranching.clean()
-
-@cli.command()
-def status():
-    """Show the working tree status."""
-    SCBranching.status()
-
-@cli.command()
-def reset():
-    """Clean and Reset all modules to remote manifest. (git reset --hard REMOTE)"""
-    SCBranching.reset()
-
-@cli.command()
-def build():
-    """Executes build related commands specified in a yaml file."""
-    pass
-
-@cli.command()
-@click.option("-n", "--no-checkout", is_flag=True, help="Do not checkout the branch.")
-@click.option("-b", "--force-broken", is_flag=True, help="Do not checkout the branch.")
-@click.option("-s", "--force-sync", is_flag=True, help="Do not checkout the branch.")
-def sync(no_checkout, force_broken, force_sync):
-    """Perform sync, and re-checkout branch"""
-    pass
-
-
 # Feature branch commands
 @cli.group()
 def feature():
@@ -293,82 +259,6 @@ def list():
 def checkout(name, force, verify):
     """Checkout a support branch."""
     SCBranching.checkout(BranchType.SUPPORT, name, force, verify)
-
-@cli.group()
-def tag():
-    pass
-
-@tag.command()
-def list():
-    """List tags in manifest or git repo."""
-    SCBranching.tag_list()
-
-@tag.command()
-@click.argument("tag")
-def show(tag):
-    """Show information about a tag in all repos."""
-    SCBranching.tag_show(tag)
-
-@tag.command()
-@click.argument("tag")
-def create(tag):
-    """Create a tag in all non READ_ONLY repos."""
-    SCBranching.tag_create(tag)
-
-@tag.command()
-@click.argument("tag")
-@click.option('-r', '--remote', is_flag=True, help="Remove in remotes as well as local.")
-def rm(tag, remote):
-    """Remove a tag in all non READ_ONLY repos."""
-    SCBranching.tag_rm(tag, remote)
-
-@tag.command()
-@click.argument("tag")
-def push(tag):
-    """Push given tag in all non READ_ONLY repos."""
-    SCBranching.tag_push(tag)
-
-@tag.command()
-@click.argument("tag")
-def check(tag):
-    """Check if a tag exists on all non READ_ONLY repos."""
-    SCBranching.tag_check(tag)
-
-@cli.group()
-def show():
-    """sc show commands."""
-    pass
-
-@show.command()
-def branch():
-    """Show the current status of branching."""
-    SCBranching.show_branch()
-
-@show.command()
-def repo_flow_config():
-    """Show git flow config for all projects."""
-    SCBranching.show_repo_flow_config()
-
-@show.command()
-def log():
-    SCBranching.show_log()
-
-@show.command()
-@click.argument("tag")
-def tag(tag):
-    """Show information about a tag."""
-    SCBranching.tag_show(tag)
-
-@show.command()
-def tags():
-    """List tags on the manifest."""
-    SCBranching.tag_list()
-
-@show.command()
-@click.argument("group", required=False)
-def group(group):
-    """List groups or show information about a group."""
-    SCBranching.group_show(group)
 
 if __name__ == '__main__':
     cli()

--- a/src/sc/branching_cli.py
+++ b/src/sc/branching_cli.py
@@ -12,14 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
-
 import click
 
 from sc.branching import SCBranching
 from sc.branching.branch import BranchType
-
-logger = logging.getLogger(__name__)
 
 @click.group()
 def cli():

--- a/src/sc/cli.py
+++ b/src/sc/cli.py
@@ -20,7 +20,8 @@ from pathlib import Path
 
 import click
 
-from . import branching_cli, clone_cli, docker_cli, review_cli, sc_logging
+from . import branching_cli, clone_cli, docker_cli, review_cli, project_cli, sc_logging
+from .help import GroupedHelp
 
 CONFIG_DIR = Path(Path.home(), '.sc_config')
 CONFIG_PATH = Path(CONFIG_DIR, 'config.yaml')
@@ -40,16 +41,17 @@ def entry_point():
     sc_logging.setup_logging(DEBUG_MODE)
     sc_logging.enable_library_logging("repo_library")
     sc_logging.enable_library_logging("git_flow_library")
-    
+
     # Add commands
-    add_commands_under_cli(branching_cli.cli)
-    add_commands_under_cli(clone_cli.cli)
-    add_commands_under_cli(docker_cli.cli)
-    add_commands_under_cli(review_cli.cli)
+    add_commands_under_cli(branching_cli.cli, "Branching", 0)
+    add_commands_under_cli(project_cli.cli, "Project", 1)
+    add_commands_under_cli(clone_cli.cli, "Clone", 2)
+    add_commands_under_cli(docker_cli.cli, "Docker", 3)
+    add_commands_under_cli(review_cli.cli, "Review", 4)
 
     cli()
 
-@click.group()
+@click.group(cls=GroupedHelp)
 def cli():
     pass
 
@@ -58,6 +60,9 @@ def version():
     """Display SC Version."""
     click.echo(metadata.version("sc"))
 
-def add_commands_under_cli(other_cli: click.Group):
+def add_commands_under_cli(other_cli: click.Group, section: str, order: int):
     for cmd in other_cli.commands.values():
+        if section:
+            setattr(cmd, "section", section)
+            setattr(cmd, "section_order", order)
         cli.add_command(cmd)

--- a/src/sc/help.py
+++ b/src/sc/help.py
@@ -1,0 +1,47 @@
+# Copyright 2025 RDK Management
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import click
+from collections import defaultdict
+
+class GroupedHelp(click.Group):
+    """
+    This class allows to set 'section' and 'section_order' attributes on click commands.
+
+    Then in the help message commands will be organised by section, in the section order
+    provided.
+    """
+    def format_commands(self, ctx, formatter):
+        sections = defaultdict(list)
+        section_order = {}
+
+        for name in self.list_commands(ctx):
+            cmd = self.get_command(ctx, name)
+            if cmd is None:
+                continue
+            if cmd.hidden:
+                continue
+
+            sec = getattr(cmd, "section", None)
+            order = getattr(cmd, "section_order", 50)
+
+            sections[sec].append((name, cmd.get_short_help_str()))
+            section_order[sec] = order
+
+        for sec in sorted(sections, key=lambda s: section_order.get(s, 50)):
+            rows = sections[sec]
+            title = f"{sec} Commands" if sec else "Other Commands"
+
+            with formatter.section(title):
+                formatter.write_dl(rows)

--- a/src/sc/help.py
+++ b/src/sc/help.py
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import click
 from collections import defaultdict
+
+import click
 
 class GroupedHelp(click.Group):
     """

--- a/src/sc/project_cli.py
+++ b/src/sc/project_cli.py
@@ -1,0 +1,122 @@
+# Copyright 2025 RDK Management
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+import click
+
+from sc.branching import SCBranching
+
+logger = logging.getLogger(__name__)
+
+@click.group()
+def cli():
+    pass
+
+@cli.command()
+def init():
+    """Initialise for branching commands."""
+    SCBranching.init()
+
+@cli.command()
+def clean():
+    """Clean all modules. (git clean -fdx)."""
+    SCBranching.clean()
+
+@cli.command()
+def status():
+    """Show the working tree status."""
+    SCBranching.status()
+
+@cli.command()
+def reset():
+    """Clean and Reset all modules to remote manifest. (git reset --hard REMOTE)"""
+    SCBranching.reset()
+
+@cli.group()
+def tag():
+    """Commands surrounding tags."""
+    pass
+
+@tag.command()
+def list():
+    """List tags in manifest or git repo."""
+    SCBranching.tag_list()
+
+@tag.command()
+@click.argument("tag")
+def show(tag):
+    """Show information about a tag in all repos."""
+    SCBranching.tag_show(tag)
+
+@tag.command()
+@click.argument("tag")
+def create(tag):
+    """Create a tag in all non READ_ONLY repos."""
+    SCBranching.tag_create(tag)
+
+@tag.command()
+@click.argument("tag")
+@click.option('-r', '--remote', is_flag=True, help="Remove in remotes as well as local.")
+def rm(tag, remote):
+    """Remove a tag in all non READ_ONLY repos."""
+    SCBranching.tag_rm(tag, remote)
+
+@tag.command()
+@click.argument("tag")
+def push(tag):
+    """Push given tag in all non READ_ONLY repos."""
+    SCBranching.tag_push(tag)
+
+@tag.command()
+@click.argument("tag")
+def check(tag):
+    """Check if a tag exists on all non READ_ONLY repos."""
+    SCBranching.tag_check(tag)
+
+@cli.group()
+def show():
+    """Show information about a project."""
+    pass
+
+@show.command()
+def branch():
+    """Show the current status of branching."""
+    SCBranching.show_branch()
+
+@show.command()
+def repo_flow_config():
+    """Show git flow config for all projects."""
+    SCBranching.show_repo_flow_config()
+
+@show.command()
+def log():
+    SCBranching.show_log()
+
+@show.command()
+@click.argument("tag")
+def tag(tag):
+    """Show information about a tag."""
+    SCBranching.tag_show(tag)
+
+@show.command()
+def tags():
+    """List tags on the manifest."""
+    SCBranching.tag_list()
+
+@show.command()
+@click.argument("group", required=False)
+def group(group):
+    """List groups or show information about a group."""
+    SCBranching.group_show(group)

--- a/src/sc/project_cli.py
+++ b/src/sc/project_cli.py
@@ -12,13 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
-
 import click
 
 from sc.branching import SCBranching
-
-logger = logging.getLogger(__name__)
 
 @click.group()
 def cli():
@@ -26,7 +22,7 @@ def cli():
 
 @cli.command()
 def init():
-    """Initialise for branching commands."""
+    """Initialise project for branching commands."""
     SCBranching.init()
 
 @cli.command()
@@ -102,11 +98,12 @@ def repo_flow_config():
 
 @show.command()
 def log():
+    """Show git log for all projects."""
     SCBranching.show_log()
 
-@show.command()
+@show.command(name="tag")
 @click.argument("tag")
-def tag(tag):
+def show_tag(tag):
     """Show information about a tag."""
     SCBranching.tag_show(tag)
 


### PR DESCRIPTION
Improves sc --help to have command sections. In this way I've moved 'branching' commands that aren't master, develop, feature, etc into a separate cli folder called Project, so they could be under a Project Commands heading. This means we don't have e.g

develop Develop commands
status Check project status
master Master commands

and instead

Branching commands
master
dev
etc

Project commands
init
status
etc

I don't know if project commands is the best heading, maybe Main branching and other branching? Let me know what you think