### PR TITLE
gh48 allow multiline commit message

### DIFF
--- a/src/sc/branching/branching.py
+++ b/src/sc/branching/branching.py
@@ -120,12 +120,13 @@ class SCBranching:
     def push(
         branch_type: BranchType,
         name: str | None = None,
+        message: str | None = None,
         run_dir: Path = Path.cwd()
     ):
         top_dir, project_type = detect_project(run_dir)
         branch = create_branch(project_type, top_dir, branch_type, name)
         run_command_by_project_type(
-            Push(top_dir, branch),
+            Push(top_dir, branch, message),
             project_type
         )
 

--- a/src/sc/branching/branching.py
+++ b/src/sc/branching/branching.py
@@ -120,13 +120,12 @@ class SCBranching:
     def push(
         branch_type: BranchType,
         name: str | None = None,
-        message: str | None = None,
         run_dir: Path = Path.cwd()
     ):
         top_dir, project_type = detect_project(run_dir)
         branch = create_branch(project_type, top_dir, branch_type, name)
         run_command_by_project_type(
-            Push(top_dir, branch, message),
+            Push(top_dir, branch),
             project_type
         )
 

--- a/src/sc/branching/commands/push.py
+++ b/src/sc/branching/commands/push.py
@@ -33,7 +33,7 @@ class Push(Command):
     branch: Branch
 
     # Repo only
-    message: str | None
+    message: str | None = None
 
     def run_git_command(self):
         repo = Repo(self.top_dir)

--- a/src/sc/branching/commands/push.py
+++ b/src/sc/branching/commands/push.py
@@ -32,6 +32,9 @@ logger = logging.getLogger(__name__)
 class Push(Command):
     branch: Branch
 
+    # Repo only
+    message: str | None
+
     def run_git_command(self):
         repo = Repo(self.top_dir)
         remote = repo.remotes[0].name
@@ -153,10 +156,12 @@ class Push(Command):
         manifest_repo = Repo(self.top_dir / '.repo' / 'manifests')
         manifest_repo.git.add(A=True)
         if manifest_repo.is_dirty():
-            msg = self._prompt_commit_msg()
+            commit_command = ["git", "commit"]
+            if self.message:
+                commit_command.extend(["-m", self.message])
             try:
                 subprocess.run(
-                    ["git", "commit", "-m", msg],
+                    commit_command,
                     cwd=self.top_dir / ".repo" / "manifests",
                     check=True
                 )
@@ -180,10 +185,3 @@ class Push(Command):
         except subprocess.CalledProcessError:
             logger.error("Failed to push manifest! Resolve errors and push again.")
             sys.exit(1)
-
-    def _prompt_commit_msg(self) -> str:
-        while True:
-            msg = input("Input commit message for manifest: ")
-            if msg:
-                return msg
-            logger.warning("Cannot provide an empty commit message!")

--- a/src/sc/branching/commands/push.py
+++ b/src/sc/branching/commands/push.py
@@ -32,9 +32,6 @@ logger = logging.getLogger(__name__)
 class Push(Command):
     branch: Branch
 
-    # Repo only
-    message: str | None = None
-
     def run_git_command(self):
         repo = Repo(self.top_dir)
         remote = repo.remotes[0].name
@@ -156,12 +153,9 @@ class Push(Command):
         manifest_repo = Repo(self.top_dir / '.repo' / 'manifests')
         manifest_repo.git.add(A=True)
         if manifest_repo.is_dirty():
-            commit_command = ["git", "commit"]
-            if self.message:
-                commit_command.extend(["-m", self.message])
             try:
                 subprocess.run(
-                    commit_command,
+                    ["git", "commit"],
                     cwd=self.top_dir / ".repo" / "manifests",
                     check=True
                 )

--- a/src/sc/branching_cli.py
+++ b/src/sc/branching_cli.py
@@ -54,7 +54,7 @@ def pull(name):
 @click.argument('name', required=False)
 @click.option("-m", "--message", help="Manifest commit message (Repo only).")
 def push(name, message):
-    """Push to remote, if a Repo project updates the manifest."""
+    """Push to remote; for Repo projects, also updates the manifest."""
     SCBranching.push(BranchType.FEATURE, name, message)
 
 
@@ -85,7 +85,7 @@ def pull():
 @develop.command()
 @click.option("-m", "--message", help="Manifest commit message (Repo only).")
 def push(message):
-    """Push develop branch to remote, if a Repo project updates the manifest."""
+    """Push to remote; for Repo projects, also updates the manifest."""
     SCBranching.push(BranchType.DEVELOP, None, message)
 
 
@@ -113,7 +113,7 @@ def pull():
 @master.command()
 @click.option("-m", "--message", help="Manifest commit message (Repo only).")
 def push(message):
-    """Push master branch to remote, if a Repo project updates the manifest."""
+    """Push to remote; for Repo projects, also updates the manifest."""
     SCBranching.push(BranchType.MASTER, None, message)
 
 
@@ -155,7 +155,7 @@ def pull(name: str | None):
 @click.argument('name', required=False)
 @click.option("-m", "--message", help="Manifest commit message (Repo only).")
 def push(name: str, message):
-    """Push release branch to remote, if a Repo project updates the manifest."""
+    """Push to remote; for Repo projects, also updates the manifest."""
     SCBranching.push(BranchType.RELEASE, name, message)
 
 @release.command()
@@ -198,7 +198,7 @@ def checkout(name, force, verify):
 @click.argument('name', required=False)
 @click.option("-m", "--message", help="Manifest commit message (Repo only).")
 def push(name, message):
-    """Push to remote, if it's a Repo project updates the manifest."""
+    """Push to remote; for Repo projects, also updates the manifest."""
     SCBranching.push(BranchType.HOTFIX, name, message)
 
 
@@ -239,7 +239,7 @@ def start(version: str, base: str):
 @click.argument('name', required=False)
 @click.option("-m", "--message", help="Manifest commit message (Repo only).")
 def push(name, message):
-    """Push to remote, if it's a Repo project updates."""
+    """Push to remote; for Repo projects, also updates the manifest."""
     SCBranching.push(BranchType.SUPPORT, name, message)
 
 

--- a/src/sc/branching_cli.py
+++ b/src/sc/branching_cli.py
@@ -52,9 +52,10 @@ def pull(name):
 
 @feature.command()
 @click.argument('name', required=False)
-def push(name):
-    """Push to remote, if a repo project updates the manifest with the lastest commits."""
-    SCBranching.push(BranchType.FEATURE, name)
+@click.option("-m", "--message", help="Manifest commit message (Repo only).")
+def push(name, message):
+    """Push to remote, if a Repo project updates the manifest."""
+    SCBranching.push(BranchType.FEATURE, name, message)
 
 
 @feature.command()
@@ -82,9 +83,10 @@ def pull():
 
 
 @develop.command()
-def push():
-    """Push develop branch to remote, if a repo project updates the manifest with the lastest commits."""
-    SCBranching.push(BranchType.DEVELOP)
+@click.option("-m", "--message", help="Manifest commit message (Repo only).")
+def push(message):
+    """Push develop branch to remote, if a Repo project updates the manifest."""
+    SCBranching.push(BranchType.DEVELOP, None, message)
 
 
 @develop.command()
@@ -109,9 +111,10 @@ def pull():
 
 
 @master.command()
-def push():
-    """Push master branch to remote, if a repo project updates the manifest with the lastest commits."""
-    SCBranching.push(BranchType.MASTER)
+@click.option("-m", "--message", help="Manifest commit message (Repo only).")
+def push(message):
+    """Push master branch to remote, if a Repo project updates the manifest."""
+    SCBranching.push(BranchType.MASTER, None, message)
 
 
 @master.command()
@@ -150,9 +153,10 @@ def pull(name: str | None):
 
 @release.command()
 @click.argument('name', required=False)
-def push(name: str):
-    """Push release branch to remote, if a repo project updates the manifest with the lastest commits."""
-    SCBranching.push(BranchType.RELEASE, name)
+@click.option("-m", "--message", help="Manifest commit message (Repo only).")
+def push(name: str, message):
+    """Push release branch to remote, if a Repo project updates the manifest."""
+    SCBranching.push(BranchType.RELEASE, name, message)
 
 @release.command()
 @click.argument('name')
@@ -192,9 +196,10 @@ def checkout(name, force, verify):
 
 @hotfix.command()
 @click.argument('name', required=False)
-def push(name):
-    """Push to remote, if it's a repo project also updates the manifest with the lastest commits."""
-    SCBranching.push(BranchType.HOTFIX, name)
+@click.option("-m", "--message", help="Manifest commit message (Repo only).")
+def push(name, message):
+    """Push to remote, if it's a Repo project updates the manifest."""
+    SCBranching.push(BranchType.HOTFIX, name, message)
 
 
 @hotfix.command()
@@ -232,9 +237,10 @@ def start(version: str, base: str):
 
 @support.command()
 @click.argument('name', required=False)
-def push(name):
-    """Push to remote, if it's a repo project also updates the manifest with the lastest commits."""
-    SCBranching.push(BranchType.SUPPORT, name)
+@click.option("-m", "--message", help="Manifest commit message (Repo only).")
+def push(name, message):
+    """Push to remote, if it's a Repo project updates."""
+    SCBranching.push(BranchType.SUPPORT, name, message)
 
 
 @support.command()

--- a/src/sc/branching_cli.py
+++ b/src/sc/branching_cli.py
@@ -52,10 +52,9 @@ def pull(name):
 
 @feature.command()
 @click.argument('name', required=False)
-@click.option("-m", "--message", help="Manifest commit message (Repo only).")
-def push(name, message):
+def push(name):
     """Push to remote; for Repo projects, also updates the manifest."""
-    SCBranching.push(BranchType.FEATURE, name, message)
+    SCBranching.push(BranchType.FEATURE, name)
 
 
 @feature.command()
@@ -83,10 +82,9 @@ def pull():
 
 
 @develop.command()
-@click.option("-m", "--message", help="Manifest commit message (Repo only).")
-def push(message):
+def push():
     """Push to remote; for Repo projects, also updates the manifest."""
-    SCBranching.push(BranchType.DEVELOP, None, message)
+    SCBranching.push(BranchType.DEVELOP, None)
 
 
 @develop.command()
@@ -111,10 +109,9 @@ def pull():
 
 
 @master.command()
-@click.option("-m", "--message", help="Manifest commit message (Repo only).")
-def push(message):
+def push():
     """Push to remote; for Repo projects, also updates the manifest."""
-    SCBranching.push(BranchType.MASTER, None, message)
+    SCBranching.push(BranchType.MASTER, None)
 
 
 @master.command()
@@ -153,10 +150,9 @@ def pull(name: str | None):
 
 @release.command()
 @click.argument('name', required=False)
-@click.option("-m", "--message", help="Manifest commit message (Repo only).")
-def push(name: str, message):
+def push(name: str):
     """Push to remote; for Repo projects, also updates the manifest."""
-    SCBranching.push(BranchType.RELEASE, name, message)
+    SCBranching.push(BranchType.RELEASE, name)
 
 @release.command()
 @click.argument('name')
@@ -196,10 +192,9 @@ def checkout(name, force, verify):
 
 @hotfix.command()
 @click.argument('name', required=False)
-@click.option("-m", "--message", help="Manifest commit message (Repo only).")
-def push(name, message):
+def push(name):
     """Push to remote; for Repo projects, also updates the manifest."""
-    SCBranching.push(BranchType.HOTFIX, name, message)
+    SCBranching.push(BranchType.HOTFIX, name)
 
 
 @hotfix.command()
@@ -237,10 +232,9 @@ def start(version: str, base: str):
 
 @support.command()
 @click.argument('name', required=False)
-@click.option("-m", "--message", help="Manifest commit message (Repo only).")
-def push(name, message):
+def push(name):
     """Push to remote; for Repo projects, also updates the manifest."""
-    SCBranching.push(BranchType.SUPPORT, name, message)
+    SCBranching.push(BranchType.SUPPORT, name)
 
 
 @support.command()

--- a/tests/branching/test_push.py
+++ b/tests/branching/test_push.py
@@ -48,9 +48,8 @@ class TestPush(unittest.TestCase):
         read_only_sha = Repo(top_dir / read_only_proj.name).head.commit.hexsha
 
         subprocess.run(
-            ["sc", "feature", "push"],
+            ["sc", "feature", "push", "-m", "donut"],
             cwd=top_dir,
-            input="donut\n",
             text=True
         )
 
@@ -100,9 +99,8 @@ class TestPush(unittest.TestCase):
         read_only_sha = Repo(top_dir / read_only_proj.name).head.commit.hexsha
 
         subprocess.run(
-            ["sc", "master", "push"],
+            ["sc", "master", "push", "-m", "donut"],
             cwd=top_dir,
-            input="donut\n",
             text=True
         )
 
@@ -152,9 +150,8 @@ class TestPush(unittest.TestCase):
         read_only_sha = Repo(top_dir / read_only_proj.name).head.commit.hexsha
 
         subprocess.run(
-            ["sc", "release", "push", "donut"],
+            ["sc", "release", "push", "donut", "-m", "donut"],
             cwd=top_dir,
-            input="donut\n",
             text=True
         )
 
@@ -204,9 +201,8 @@ class TestPush(unittest.TestCase):
         read_only_sha = Repo(top_dir / read_only_proj.name).head.commit.hexsha
 
         subprocess.run(
-            ["sc", "develop", "push"],
+            ["sc", "develop", "push", "-m", "donut"],
             cwd=top_dir,
-            input="donut\n",
             text=True
         )
 
@@ -256,9 +252,8 @@ class TestPush(unittest.TestCase):
         read_only_sha = Repo(top_dir / read_only_proj.name).head.commit.hexsha
 
         subprocess.run(
-            ["sc", "support", "push", "donut"],
+            ["sc", "support", "push", "donut", "-m", "donut"],
             cwd=top_dir,
-            input="donut\n",
             text=True
         )
 
@@ -308,9 +303,8 @@ class TestPush(unittest.TestCase):
         read_only_sha = Repo(top_dir / read_only_proj.name).head.commit.hexsha
 
         subprocess.run(
-            ["sc", "hotfix", "push", "donut"],
+            ["sc", "hotfix", "push", "donut", "-m", "donut"],
             cwd=top_dir,
-            input="donut\n",
             text=True
         )
 
@@ -348,7 +342,7 @@ class TestPush(unittest.TestCase):
 
         with self.assertRaises(subprocess.CalledProcessError) as cm:
             subprocess.run(
-                ["sc", "feature", "push"], input="donut\n",
+                ["sc", "feature", "push", "-m", "donut"],
                 cwd=top_dir, capture_output=True, check=True, text=True)
 
         self.assertIn("Repository validation failed", cm.exception.stdout)
@@ -360,7 +354,7 @@ class TestPush(unittest.TestCase):
 
         subprocess.run(["sc", "feature", "start", "donut"], cwd=top_dir)
         output = subprocess.run(
-            ["sc", "feature", "push"], input="donut\n",
+            ["sc", "feature", "push", "-m", "donut"],
             cwd=top_dir, capture_output=True, text=True
         )
 

--- a/tests/branching/test_push.py
+++ b/tests/branching/test_push.py
@@ -11,9 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import os
 import shutil
+import stat
 import subprocess
+import tempfile
 import unittest
 
 from git import Repo
@@ -22,6 +24,22 @@ from sc_manifest_parser import ScManifest
 from .repo_client_creator import RepoTestClientCreator
 
 class TestPush(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # Override git's commit editor
+        cls.script = tempfile.NamedTemporaryFile(delete=False, mode="w")
+        cls.script.write("#!/usr/bin/env sh\necho test > \"$1\"\n")
+        cls.script.close()
+
+        os.chmod(cls.script.name, os.stat(cls.script.name).st_mode | stat.S_IEXEC)
+
+        cls.env = os.environ.copy()
+        cls.env["GIT_EDITOR"] = cls.script.name
+
+    @classmethod
+    def tearDownClass(cls):
+        os.unlink(cls.script.name)
+
     def setUp(self):
         self.repo_client = RepoTestClientCreator()
 
@@ -48,9 +66,8 @@ class TestPush(unittest.TestCase):
         read_only_sha = Repo(top_dir / read_only_proj.name).head.commit.hexsha
 
         subprocess.run(
-            ["sc", "feature", "push", "-m", "donut"],
-            cwd=top_dir,
-            text=True
+            ["sc", "feature", "push"],
+            cwd=top_dir, text=True, env=self.env
         )
 
         manifest = ScManifest.from_repo_root(top_dir / ".repo")
@@ -99,9 +116,8 @@ class TestPush(unittest.TestCase):
         read_only_sha = Repo(top_dir / read_only_proj.name).head.commit.hexsha
 
         subprocess.run(
-            ["sc", "master", "push", "-m", "donut"],
-            cwd=top_dir,
-            text=True
+            ["sc", "master", "push"],
+            cwd=top_dir, text=True, env=self.env
         )
 
         manifest = ScManifest.from_repo_root(top_dir / ".repo")
@@ -150,9 +166,8 @@ class TestPush(unittest.TestCase):
         read_only_sha = Repo(top_dir / read_only_proj.name).head.commit.hexsha
 
         subprocess.run(
-            ["sc", "release", "push", "donut", "-m", "donut"],
-            cwd=top_dir,
-            text=True
+            ["sc", "release", "push", "donut"],
+            cwd=top_dir, text=True, env=self.env
         )
 
         manifest = ScManifest.from_repo_root(top_dir / ".repo")
@@ -201,9 +216,8 @@ class TestPush(unittest.TestCase):
         read_only_sha = Repo(top_dir / read_only_proj.name).head.commit.hexsha
 
         subprocess.run(
-            ["sc", "develop", "push", "-m", "donut"],
-            cwd=top_dir,
-            text=True
+            ["sc", "develop", "push"],
+            cwd=top_dir, text=True, env=self.env
         )
 
         manifest = ScManifest.from_repo_root(top_dir / ".repo")
@@ -252,9 +266,8 @@ class TestPush(unittest.TestCase):
         read_only_sha = Repo(top_dir / read_only_proj.name).head.commit.hexsha
 
         subprocess.run(
-            ["sc", "support", "push", "donut", "-m", "donut"],
-            cwd=top_dir,
-            text=True
+            ["sc", "support", "push", "donut"],
+            cwd=top_dir, text=True, env=self.env
         )
 
         manifest = ScManifest.from_repo_root(top_dir / ".repo")
@@ -303,9 +316,8 @@ class TestPush(unittest.TestCase):
         read_only_sha = Repo(top_dir / read_only_proj.name).head.commit.hexsha
 
         subprocess.run(
-            ["sc", "hotfix", "push", "donut", "-m", "donut"],
-            cwd=top_dir,
-            text=True
+            ["sc", "hotfix", "push", "donut"],
+            cwd=top_dir, text=True, env=self.env
         )
 
         manifest = ScManifest.from_repo_root(top_dir / ".repo")
@@ -342,8 +354,8 @@ class TestPush(unittest.TestCase):
 
         with self.assertRaises(subprocess.CalledProcessError) as cm:
             subprocess.run(
-                ["sc", "feature", "push", "-m", "donut"],
-                cwd=top_dir, capture_output=True, check=True, text=True)
+                ["sc", "feature", "push"],
+                cwd=top_dir, capture_output=True, check=True, text=True, env=self.env)
 
         self.assertIn("Repository validation failed", cm.exception.stdout)
 
@@ -354,8 +366,8 @@ class TestPush(unittest.TestCase):
 
         subprocess.run(["sc", "feature", "start", "donut"], cwd=top_dir)
         output = subprocess.run(
-            ["sc", "feature", "push", "-m", "donut"],
-            cwd=top_dir, capture_output=True, text=True
+            ["sc", "feature", "push"],
+            cwd=top_dir, capture_output=True, text=True, env=self.env
         )
 
         self.assertIn("Remote already contains commit. Skipping.", output.stdout)


### PR DESCRIPTION
Closes #48 

Adds a -m flag to sc push for a manifest commit message (mostly just for testing) then return normal sc push to using git auto commit message editing.