### PR TITLE
gh50 dev branches not pushing

### DIFF
--- a/src/sc/branching/branch.py
+++ b/src/sc/branching/branch.py
@@ -41,7 +41,7 @@ class Branch:
     suffix: str = None
 
     def __post_init__(self):
-        if not self.suffix and not self._is_primary_branch:
+        if not self.suffix and not self.is_primary_branch():
             raise ValueError("Can't create non primary branch with no suffix.")
 
     @property
@@ -50,5 +50,5 @@ class Branch:
             return f"{self.type}/{self.suffix}"
         return str(self.type)
 
-    def _is_primary_branch(self) -> bool:
+    def is_primary_branch(self) -> bool:
         return self.type in {BranchType.DEVELOP, BranchType.MASTER}

--- a/src/sc/branching/commands/push.py
+++ b/src/sc/branching/commands/push.py
@@ -103,7 +103,10 @@ class Push(Command):
         if not self._local_branch_exists(proj_repo, proj_branch_name):
             logger.info("Branch doesn't exist in project. Skipping.")
             return False
-        if self._remote_contains_commit(proj_repo, proj.remote):
+        if (
+            not self.branch.is_primary_branch()
+            and self._remote_contains_commit(proj_repo, proj.remote)
+        ):
             logger.info("Remote already contains commit. Skipping.")
             return False
         return True


### PR DESCRIPTION
Closes #50 

Due to check for remote commit existing when pushing branches, when merging a feature branch that was pushed back into develop, then pushing develop, this will cause that branch not to push as the commit already exists on the feature branch.