### PR TITLE
gh61 sc pull lfs pull

### DIFF
--- a/src/sc/branching/commands/pull.py
+++ b/src/sc/branching/commands/pull.py
@@ -77,8 +77,7 @@ class Pull(Command):
             if remote_branch in remote_refs:
                 project_repo.git.branch('-u', remote_branch, proj_branch_name)
 
-            project_repo.git.lfs('fetch')
-            project_repo.git.lfs('checkout')
+            project_repo.git.lfs('pull')
 
         if errors:
             logger.error("Failed to merge pull in:\n" + "\n".join(errors))


### PR DESCRIPTION
Closes #61

On old sc pull, at the end we run git lfs pull. On new sc it is mistakenly doing git lfs fetch, git lfs checkout. Need to lfs pull at the end of a pull.