### PR TITLE
fix(docker): validate registry URL on login + add docker subcommand tests (#64)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,17 +23,17 @@ SC is a collection of CLI tools, centered around version control and docker work
 
 ## Installing
 
-`pip` is the default Python package manager, but Ubuntu 23.04+ prevents global installs. Rather than relying on virtual environments, we recommend `uv` for faster performance and simpler global CLI tool management.
+`pip` is the default Python package manager, but Ubuntu 23.04+ prevents global installs. We recommend `uv` (fastest) or `pipx` (isolated global tools) instead of plain `pip`.
 
-### pip
+| Method | When to use | Notes |
+| ------ | ----------- | ----- |
+| `uv`   | Default choice | Fastest install / upgrade, simplest global CLI tool management |
+| `pipx` | Existing pipx workflow | Each tool gets its own isolated virtualenv automatically |
+| `pip`  | Already in a venv | Direct, but blocked by PEP 668 on modern distros for global installs |
 
-```shell
-pip install git+https://github.com/rdkcentral/sc.git@main
-```
+### uv (recommended)
 
-### uv
-
-See the uv install guide [here.](https://docs.astral.sh/uv/getting-started/installation/)
+See the [uv install guide](https://docs.astral.sh/uv/getting-started/installation/).
 
 ```shell
 # Install sc as a global tool
@@ -41,9 +41,57 @@ uv tool install git+https://github.com/rdkcentral/sc.git@main
 
 sc --help
 
-# Update sc to latest
+# Update sc to the latest main
 uv tool upgrade sc
+
+# Pin to a specific release (recommended for shared / CI hosts)
+uv tool install git+https://github.com/rdkcentral/sc.git@1.0.15
 
 # Uninstall sc
 uv tool uninstall sc
+```
+
+### pipx
+
+See the [pipx install guide](https://pipx.pypa.io/stable/installation/).
+
+```shell
+# Install sc as a global isolated tool
+pipx install git+https://github.com/rdkcentral/sc.git@main
+
+sc --help
+
+# Update sc to the latest main
+pipx upgrade sc
+
+# Pin to a specific release
+pipx install --force git+https://github.com/rdkcentral/sc.git@1.0.15
+
+# Uninstall sc
+pipx uninstall sc
+```
+
+### pip
+
+Only inside an activated virtualenv:
+
+```shell
+pip install git+https://github.com/rdkcentral/sc.git@main
+```
+
+### Check your install
+
+```shell
+sc --version          # show version
+sc docker --help      # confirm docker subcommand is wired up
+```
+
+If you've installed previously and the version looks out of date, check
+which install path is on `PATH`:
+
+```shell
+which sc
+# uv:    ~/.local/share/uv/tools/sc/bin/sc
+# pipx:  ~/.local/share/pipx/venvs/sc/bin/sc → ~/.local/bin/sc
+# pip:   inside your virtualenv
 ```

--- a/docs/docker/login.md
+++ b/docs/docker/login.md
@@ -1,41 +1,109 @@
 # sc docker login
 
-After using this command you will be prompted for different options for your login.
+`sc docker login` adds a remote container registry to your SC config so
+you can `sc docker run <image>` images you don't already have pulled
+locally. (For images already pulled, the `--local` flag on `sc docker run`
+skips the login flow entirely.)
 
-- Registry to login:
- > This should include the base URL and relevant namespace. \
- > Example (GitHub): ghcr.io/organisation \
- > Example (Artifactory): your.artifactory.com/docker-registry
-- Registry type: Currently the supported registry types are `github` or `artifactory`
-- Use netrc?: Choose `y` to attempt to use credentials from your netrc or `n` for manual entry of credentials.
-- Username/Api Key: This is only asked if you chose `n`, manually enter your username and api key for the registry
- > GitHub requires your username and Personal Access Token (see below for information on generating PAT) \
- > Artifactory requires your username and API key (see below for information on generating API key)
+You'll be prompted for four pieces of input.
 
+## 1. Registry URL
+
+Must include both the **host** and the **namespace** (path), separated by `/`.
+
+| Registry type | Example URL                              |
+| ------------- | ---------------------------------------- |
+| GHCR          | `ghcr.io/myorg`                          |
+| Artifactory   | `your.artifactory.com/docker-registry`   |
+
+> [!IMPORTANT]
+> Don't paste the prompt prefix (`> : `) into the answer — paste only the
+> URL. Whitespace and leading prompt prefixes are stripped + validated,
+> and `sc` will reject the input with a clear error if the URL doesn't
+> match the expected `host/namespace` shape (see [#64](https://github.com/rdkcentral/sc/issues/64)).
+
+## 2. Registry Type
+
+Currently the supported registry types are `github` or `artifactory`.
+
+## 3. Use netrc?
+
+- `y` — `sc` reads the username and API key for the registry's host from
+  your `~/.netrc` file.
+- `n` — `sc` prompts you to enter the username and API key manually, and
+  stores them in `~/.sc_config/config.yaml`.
+
+## 4. Username / API Key (only asked if you chose `n`)
+
+| Registry    | Username           | Credential                                                                                                |
+| ----------- | ------------------ | --------------------------------------------------------------------------------------------------------- |
+| GHCR        | GitHub username    | [Personal Access Token (classic)](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic) |
+| Artifactory | Artifactory username | API Key (Profile → API Key) — see note about PAT migration below                                        |
+
+---
 
 ## Obtaining Credentials
 
-### GitHub Container Registry (GHCR):
+### GitHub Container Registry (GHCR)
 
-To create a Personal Access Token (PAT) for GitHub, follow the instructions [here.](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic)
+To create a Personal Access Token (PAT) for GitHub, follow the instructions
+[here](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic).
 
-### Artifactory:
+### Artifactory
 
 Currently, we use API Keys to access Artifactory. Find yours by:
-- Clicking your profile icon in the top-right corner.
-- Selecting Edit Profile.
-- Scrolling down to API Key.
 
-Note: Artifactory will transition to using Personal Access Tokens in Q4 2024. We will update this guide with the new instructions at that time.
+1. Click your profile icon in the top-right corner.
+2. Select **Edit Profile**.
+3. Scroll down to **API Key**.
 
-## Example .netrc file
+> [!NOTE]
+> Artifactory will transition to using Personal Access Tokens in Q4 2024.
+> We will update this guide with the new instructions at that time.
+
+## Example `.netrc` file
 
 ```
-machine example.artifactory.com 
+machine example.artifactory.com
 login <Your Username>
-password <Your API Key> 
+password <Your API Key>
 
-machine ghcr.io 
+machine ghcr.io
 login  <Your Username>
-password <Yout Personal Access Token>
+password <Your Personal Access Token>
 ```
+
+Make sure the file is owned by you and not world-readable:
+
+```shell
+chmod 600 ~/.netrc
+```
+
+## Troubleshooting
+
+### `not enough values to unpack (expected 2, got 1)` or `No authenticators found for machine '> : …'`
+
+You likely pasted with the prompt prefix included (e.g. `> : ghcr.io/myorg`)
+or omitted the namespace. Re-run `sc docker login` and paste the URL only
+— `<host>/<namespace>`, no prefix, no trailing slash. Fixed by validation
+added in [#64](https://github.com/rdkcentral/sc/issues/64).
+
+### "WARNING: You have not logged into any registries…"
+
+If you only need to run an image you already have pulled, skip login:
+
+```shell
+sc docker run <image> --local /bin/bash
+```
+
+### Token rejected with `Bad Credentials`
+
+The token in `~/.netrc` or `~/.sc_config/config.yaml` has expired. Generate
+a fresh one (see [Obtaining Credentials](#obtaining-credentials)), update
+the file, then re-run `sc docker login`.
+
+### Anonymous list works but login fails
+
+Some Artifactory namespaces allow anonymous read. If you only need
+`sc docker list` (not `run` of remote images), you can skip login
+altogether — leave `~/.sc_config/config.yaml` empty.

--- a/src/sc/docker/docker.py
+++ b/src/sc/docker/docker.py
@@ -17,6 +17,7 @@ import grp
 from netrc import netrc, NetrcParseError
 import os
 from pathlib import Path
+import re
 import shlex
 import socket
 import subprocess
@@ -181,6 +182,36 @@ class SCDocker:
             sys.exit(1)
 
     def _validate_registry_on_login(self, registry: str):
+        # Format checks first — catch whitespace, prompt-prefix paste
+        # accidents (e.g. "> : ghcr.io/myorg"), schemes (https://...),
+        # and missing /namespace before they reach the registry API and
+        # surface cryptic downstream errors like "not enough values to
+        # unpack" (#64).
+        def _reject(reason):
+            click.secho(
+                f"ERROR: invalid registry URL '{registry}' — {reason}.",
+                fg="red")
+            click.secho(
+                "Expected <host>/<namespace>, e.g. ghcr.io/myorg or "
+                "your.artifactory.com/docker-registry.", fg="red")
+            sys.exit(1)
+
+        if not registry:
+            _reject("empty")
+        if any(c.isspace() for c in registry):
+            _reject("contains whitespace")
+        if "://" in registry:
+            _reject("drop the scheme (http://, https://) — host only")
+        if "/" not in registry:
+            _reject("missing /<namespace>")
+        host, _, path = registry.partition("/")
+        if not host or not path:
+            _reject("missing host or namespace")
+        if not re.match(r'^[a-zA-Z0-9][a-zA-Z0-9._:-]*$', host):
+            _reject(f"host '{host}' has invalid characters")
+        if not re.match(r'^[a-zA-Z0-9][a-zA-Z0-9._/-]*$', path):
+            _reject(f"namespace '{path}' has invalid characters")
+
         if not self.whitelisted_registries or registry in self.whitelisted_registries:
             return
 
@@ -268,7 +299,7 @@ class SCDocker:
         click.echo("Example (GitHub): ghcr.io/organisation")
         click.echo("Example (Artifactory): your.artifactory.com/docker-registry")
 
-        registry_url = click.prompt("> ")
+        registry_url = click.prompt("> ").strip()
         self._validate_registry_on_login(registry_url)
 
         return registry_url

--- a/src/sc/docker/registry_apis/artifactory.py
+++ b/src/sc/docker/registry_apis/artifactory.py
@@ -20,6 +20,10 @@ class ArtifactoryAPI(RegistryAPI):
     reg_type = "Artifactory"
 
     def fetch_images(self, registry, username, token) -> tuple[str, ...]:
+        if '/' not in registry:
+            raise ValueError(
+                f"Artifactory registry URL must include a namespace, "
+                f"e.g. '{registry}/<namespace>', got '{registry}'")
         artifactory_root, repo = registry.split('/', 1)
         if not username:
             raise ValueError("Username is required for Artifactory API")
@@ -34,6 +38,10 @@ class ArtifactoryAPI(RegistryAPI):
             raise self.RegistryAPIException(self.reg_type, registry, response = response)
 
     def fetch_tags(self, registry, username, token, container_name) -> tuple[str, ...]:
+        if '/' not in registry:
+            raise ValueError(
+                f"Artifactory registry URL must include a namespace, "
+                f"e.g. '{registry}/<namespace>', got '{registry}'")
         artifactory_root, repo = registry.split('/', 1)
         if not username:
             raise ValueError("Username is required for Artifactory API")

--- a/tests/docker/test_registry_apis.py
+++ b/tests/docker/test_registry_apis.py
@@ -1,0 +1,53 @@
+# Copyright 2026 RDK Management
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Defensive guards on Artifactory registry API methods (issue #64)."""
+
+import unittest
+
+from sc.docker.registry_apis.artifactory import ArtifactoryAPI
+
+
+class TestArtifactoryFetchImages(unittest.TestCase):
+
+    def setUp(self):
+        self.api = ArtifactoryAPI()
+
+    def test_missing_namespace_raises_value_error(self):
+        # The "not enough values to unpack" crash from #64 — now a clean
+        # ValueError with a hint that points at the fix.
+        with self.assertRaises(ValueError) as cm:
+            self.api.fetch_images(
+                "example.artifactory.com", "user", "token")
+        self.assertIn("namespace", str(cm.exception).lower())
+
+    def test_empty_registry_raises_value_error(self):
+        with self.assertRaises(ValueError):
+            self.api.fetch_images("", "user", "token")
+
+
+class TestArtifactoryFetchTags(unittest.TestCase):
+
+    def setUp(self):
+        self.api = ArtifactoryAPI()
+
+    def test_missing_namespace_raises_value_error(self):
+        with self.assertRaises(ValueError) as cm:
+            self.api.fetch_tags(
+                "example.artifactory.com", "user", "token", "some-image")
+        self.assertIn("namespace", str(cm.exception).lower())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/docker/test_validate_registry.py
+++ b/tests/docker/test_validate_registry.py
@@ -1,0 +1,147 @@
+# Copyright 2026 RDK Management
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for registry URL validation in sc.docker.docker (issue #64)."""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from sc.docker.docker import SCDocker
+
+
+def _make_sc_docker(whitelist=None):
+    """Build a SCDocker with the bits we don't exercise stubbed out."""
+    sc = SCDocker.__new__(SCDocker)
+    sc.whitelisted_registries = whitelist
+    return sc
+
+
+class TestValidateRegistryOnLogin(unittest.TestCase):
+    """_validate_registry_on_login rejects malformed registry URLs (#64)."""
+
+    def setUp(self):
+        self.sc = _make_sc_docker()
+
+    # ---- valid ---------------------------------------------------------
+
+    def test_ghcr_org_url_is_accepted(self):
+        # Should not exit.
+        self.sc._validate_registry_on_login("ghcr.io/myorg")
+
+    def test_artifactory_namespace_url_is_accepted(self):
+        self.sc._validate_registry_on_login("example.artifactory.com/docker-registry")
+
+    def test_artifactory_nested_namespace_is_accepted(self):
+        self.sc._validate_registry_on_login(
+            "example.artifactory.com/docker-registry/sub/path")
+
+    def test_host_with_port_is_accepted(self):
+        self.sc._validate_registry_on_login("localhost:5000/myrepo")
+
+    def test_hyphenated_labels_are_accepted(self):
+        self.sc._validate_registry_on_login("my-registry.example.com/my-repo")
+
+    # ---- invalid -------------------------------------------------------
+
+    def test_host_without_namespace_exits(self):
+        # Reproduces the original "not enough values to unpack" failure mode.
+        with self.assertRaises(SystemExit):
+            self.sc._validate_registry_on_login("example.artifactory.com")
+
+    def test_prompt_prefix_pasted_into_input_exits(self):
+        # The exact paste accident from the bug report.
+        with self.assertRaises(SystemExit):
+            self.sc._validate_registry_on_login(
+                "> : example.artifactory.com/docker-registry")
+
+    def test_leading_whitespace_exits(self):
+        with self.assertRaises(SystemExit):
+            self.sc._validate_registry_on_login(
+                "  example.artifactory.com/docker-registry")
+
+    def test_trailing_whitespace_exits(self):
+        with self.assertRaises(SystemExit):
+            self.sc._validate_registry_on_login(
+                "example.artifactory.com/docker-registry  ")
+
+    def test_protocol_in_url_exits(self):
+        # `host` shouldn't be a URL — strip scheme.
+        with self.assertRaises(SystemExit):
+            self.sc._validate_registry_on_login("https://ghcr.io/myorg")
+
+    def test_empty_string_exits(self):
+        with self.assertRaises(SystemExit):
+            self.sc._validate_registry_on_login("")
+
+    def test_just_a_slash_exits(self):
+        with self.assertRaises(SystemExit):
+            self.sc._validate_registry_on_login("/")
+
+    def test_localhost_registry_is_accepted(self):
+        # `localhost/myrepo` is a perfectly valid local-registry URL.
+        # Docker spec is permissive about the host part.
+        self.sc._validate_registry_on_login("localhost/myrepo")
+
+    # ---- whitelist interplay ------------------------------------------
+
+    def test_whitelist_rejection_runs_after_format_check(self):
+        sc = _make_sc_docker(whitelist=["ghcr.io/allowed"])
+        with self.assertRaises(SystemExit):
+            sc._validate_registry_on_login("ghcr.io/not-allowed")
+
+    def test_whitelist_allowed_url_is_accepted(self):
+        sc = _make_sc_docker(whitelist=["ghcr.io/allowed"])
+        sc._validate_registry_on_login("ghcr.io/allowed")
+
+
+class TestPromptRegistryUrlStripsInput(unittest.TestCase):
+    """_prompt_registry_url strips whitespace before validating (#64)."""
+
+    def test_input_with_surrounding_whitespace_is_stripped_then_accepted(self):
+        import click
+        sc = _make_sc_docker()
+
+        captured = {}
+
+        @click.command()
+        def fake_cmd():
+            captured["result"] = sc._prompt_registry_url()
+
+        result = CliRunner().invoke(
+            fake_cmd, input="  ghcr.io/myorg  \n", catch_exceptions=False)
+        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(captured["result"], "ghcr.io/myorg")
+
+    def test_input_with_prompt_prefix_is_rejected_with_clear_error(self):
+        import click
+        sc = _make_sc_docker()
+
+        @click.command()
+        def fake_cmd():
+            sc._prompt_registry_url()
+
+        # Click's prompt() retries on each empty line; supply one line then
+        # nothing else so the eventual SystemExit from the validator surfaces.
+        result = CliRunner().invoke(
+            fake_cmd,
+            input="> : ghcr.io/myorg\n",
+            catch_exceptions=False)
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("invalid registry URL", result.output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #64.

`/cc @TB-1993` — code owner per recent reviewer history.

## Summary

`sc docker login` previously accepted whitespace, prompt-prefix paste accidents (e.g. `> : ghcr.io/myorg`), URLs with schemes (`https://...`), and host-only URLs missing the `/<namespace>` path. The bad URL was stored and surfaced either as the cryptic Python error `not enough values to unpack (expected 2, got 1)` (when `ArtifactoryAPI` tried `split('/', 1)` on a host with no `/`) or `No authenticators found for machine '> : host…' in .netrc`.

This PR validates the URL at the prompt, adds defensive guards on the Artifactory API methods, and fills in the missing test coverage on the `sc.docker` subcommand (previously zero tests).

## Code changes

### `src/sc/docker/docker.py`

- `_prompt_registry_url` now strips whitespace from the click input before validating.
- `_validate_registry_on_login` enforces: non-empty, no whitespace, no scheme, must contain `/`, host and namespace each match a conservative character set. Rejection prints a clear error pointing at the expected `<host>/<namespace>` format with examples.

### `src/sc/docker/registry_apis/artifactory.py`

- `fetch_images` and `fetch_tags` now raise `ValueError` with an actionable hint instead of crashing with `not enough values to unpack` if a caller ever bypasses the prompt and passes a registry without a `/`.

## New tests (`tests/docker/`)

The `sc.docker` subcommand previously had **no test coverage** — that's why this bug slipped through. Adding:

- **`test_validate_registry.py`** (17 cases):
  - Valid: ghcr.io org URL, artifactory namespace URL (incl. nested), `localhost:5000/myrepo`, hyphenated labels, `localhost/myrepo`, whitelist-allowed.
  - Invalid: host-only (no namespace), prompt-prefix paste, leading/trailing whitespace, scheme-prefixed (`https://...`), empty, just `/`.
  - Whitelist interplay: format check runs before whitelist; whitelist rejection still works.
  - 2 `CliRunner` cases driving `_prompt_registry_url` end-to-end to confirm the strip + reject behaviour at the prompt layer.
- **`test_registry_apis.py`** (3 cases):
  - `ArtifactoryAPI.fetch_images` / `fetch_tags` raise `ValueError` with "namespace" in the message when the registry has no `/`.

Local run:

```
$ python -m unittest discover tests/docker -v
…
Ran 20 tests in 0.003s
OK
```

## Docs changes

### `docs/docker/login.md`

Rewritten with:

- Explicit URL-format guidance (host + namespace, separated by `/`) and an examples table.
- A "don't paste the prompt prefix" call-out tied to the validation behaviour added here.
- A **Troubleshooting** section covering the exact error messages from this issue, plus the `chmod 600 ~/.netrc` reminder and the "skip login when image is already pulled" path.
- A note about anonymous-readable Artifactory namespaces (no login needed for `sc docker list` in that case).

### `README.md`

- Adds **`pipx`** install instructions alongside `uv` and `pip`.
- Comparison table for choosing between the three.
- Version-pinning examples for both `uv` and `pipx`.
- "Check your install" recipe to disambiguate `which sc` between `uv`/`pipx`/`pip` install locations.

## Test plan

- [x] Manual reproduction of original failure mode and verification of fix on Linux + `sc` 1.0.6.
- [x] `python -m unittest discover tests/docker -v` — 20/20 pass.
- [ ] CI workflow on the PR.
- [ ] Manual verification of docs links and rendering on a preview.