### PR TITLE
Feature/bwdo 809 implement lock clone cache

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
         'pyyaml~=6.0',
         'rich>=14',
         'requests==2.31.0', # Docker SDK breaks on 2.32.0
+        'filelock==3.29.7',
         'repo_library @ git+https://github.com/rdkcentral/sc-repo-library.git@master',
         'git_flow_library @ git+https://github.com/rdkcentral/sc-git-flow-library.git@master',
         'sc_manifest_parser @ git+https://github.com/rdkcentral/sc-manifest-parser.git@main'

--- a/src/sc/clone/cloners/repo_cloner.py
+++ b/src/sc/clone/cloners/repo_cloner.py
@@ -89,9 +89,10 @@ class RepoCloner(Cloner):
         started = time.monotonic()
         lock = FileLock(CACHE_LOCK_PATH)
 
+        logger.info("Acquiring cache lock.")
         while True:
             try:
-                lock.acquire(timeout=5)
+                lock.acquire(timeout=20)
                 break
             except Timeout:
                 waited = int(time.monotonic() - started)
@@ -101,9 +102,10 @@ class RepoCloner(Cloner):
                     )
                 else:
                     logger.error(
-                        f"Cache remained lock past the set wait time of {CACHE_MAX_WAIT} seconds."
+                        f"Cache remained locked past the set wait time of {CACHE_MAX_WAIT} seconds."
                     )
                     sys.exit(1)
+        logger.info("Cache lock acquired.")
 
         try:
             reference = self._cache()

--- a/src/sc/clone/cloners/repo_cloner.py
+++ b/src/sc/clone/cloners/repo_cloner.py
@@ -19,6 +19,7 @@ import shutil
 import subprocess
 import sys
 
+from filelock import FileLock, Timeout
 from pydantic import BaseModel
 
 from .cloner import Cloner, RefType
@@ -29,6 +30,7 @@ from sc_manifest_parser import ScManifest
 logger = logging.getLogger(__name__)
 
 REPO_CACHE_DIR = Path.home() / ".caches"
+LOCK_FILE_PATH = REPO_CACHE_DIR / ".lock"
 
 class RepoClonerConfig(BaseModel):
     """
@@ -74,8 +76,19 @@ class RepoCloner(Cloner):
         - Parses the manifest to retrieve projects.
         - Initializes GitFlow for all unlocked projects.
         """
-        reference = self._cache() if self.config.cache else None
+        if self.config.cache:
+            REPO_CACHE_DIR.mkdir(exist_ok=True)
+            try:
+                with FileLock(LOCK_FILE_PATH, timeout=600):
+                    reference = self._cache()
+                    self._clone(directory, reference)
+            except Timeout:
+                logger.error(f"The cache lock file {LOCK_FILE_PATH} remained 10 minutes.")
+                sys.exit(1)
+        else:
+            self._clone(directory, None)
 
+    def _clone(self, directory: Path, reference: Path | None):
         self._init_repo(directory=directory, reference=reference)
         RepoLibrary.sync(
             directory,
@@ -95,7 +108,6 @@ class RepoCloner(Cloner):
         Returns:
             Path: The directory of the mirrored cache.
         """
-        REPO_CACHE_DIR.mkdir(exist_ok=True)
         manifest_hostname = self._get_manifest_hostname(self.config.uri)
         host_cache_dir = Path(REPO_CACHE_DIR / manifest_hostname)
         host_cache_dir.mkdir(exist_ok=True)

--- a/src/sc/clone/cloners/repo_cloner.py
+++ b/src/sc/clone/cloners/repo_cloner.py
@@ -18,6 +18,7 @@ from pathlib import Path
 import shutil
 import subprocess
 import sys
+import time
 
 from filelock import FileLock, Timeout
 from pydantic import BaseModel
@@ -30,7 +31,8 @@ from sc_manifest_parser import ScManifest
 logger = logging.getLogger(__name__)
 
 REPO_CACHE_DIR = Path.home() / ".caches"
-LOCK_FILE_PATH = REPO_CACHE_DIR / ".lock"
+CACHE_LOCK_PATH = REPO_CACHE_DIR / ".lock"
+CACHE_MAX_WAIT = 600
 
 class RepoClonerConfig(BaseModel):
     """
@@ -77,18 +79,39 @@ class RepoCloner(Cloner):
         - Initializes GitFlow for all unlocked projects.
         """
         if self.config.cache:
-            REPO_CACHE_DIR.mkdir(exist_ok=True)
-            try:
-                with FileLock(LOCK_FILE_PATH, timeout=600):
-                    reference = self._cache()
-                    self._clone(directory, reference)
-            except Timeout:
-                logger.error(f"The cache lock file {LOCK_FILE_PATH} remained 10 minutes.")
-                sys.exit(1)
+            self._clone_with_cache(directory)
         else:
-            self._clone(directory, None)
+            self._clone(directory)
 
-    def _clone(self, directory: Path, reference: Path | None):
+    def _clone_with_cache(self, directory: Path):
+        REPO_CACHE_DIR.mkdir(exist_ok=True)
+
+        started = time.monotonic()
+        lock = FileLock(CACHE_LOCK_PATH)
+
+        while True:
+            try:
+                lock.acquire(timeout=5)
+                break
+            except Timeout:
+                waited = int(time.monotonic() - started)
+                if waited < CACHE_MAX_WAIT:
+                    logger.info(
+                        f"Cache is in use by another process, waited {waited} seconds..."
+                    )
+                else:
+                    logger.error(
+                        f"Cache remained lock past the set wait time of {CACHE_MAX_WAIT} seconds."
+                    )
+                    sys.exit(1)
+
+        try:
+            reference = self._cache()
+            self._clone(directory, reference)
+        finally:
+            lock.release()
+
+    def _clone(self, directory: Path, reference: Path | None = None):
         self._init_repo(directory=directory, reference=reference)
         RepoLibrary.sync(
             directory,

--- a/src/sc/clone/cloners/repo_cloner.py
+++ b/src/sc/clone/cloners/repo_cloner.py
@@ -20,7 +20,7 @@ import subprocess
 import sys
 import time
 
-from filelock import FileLock, Timeout
+from filelock import SoftFileLock, Timeout
 from pydantic import BaseModel
 
 from .cloner import Cloner, RefType
@@ -86,15 +86,14 @@ class RepoCloner(Cloner):
     def _clone_with_cache(self, directory: Path):
         REPO_CACHE_DIR.mkdir(exist_ok=True)
 
-        lock = FileLock(CACHE_LOCK_PATH)
-        lock_acquired = self._acquire_cache_lock(lock)
+        lock = SoftFileLock(CACHE_LOCK_PATH)
+        self._acquire_cache_lock(lock)
 
         try:
             reference = self._cache()
             self._clone(directory, reference)
         finally:
-            if lock_acquired:
-                lock.release()
+            lock.release()
 
     def _clone(self, directory: Path, reference: Path | None = None):
         self._init_repo(directory=directory, reference=reference)
@@ -159,11 +158,8 @@ class RepoCloner(Cloner):
             logger.error(f"repo init error: {e}")
             sys.exit(1)
 
-    def _acquire_cache_lock(self, lock: FileLock) -> bool:
-        """Try to acquire cache lock. After a certain time bypass it.
-
-        Return True if lock acquired or False if bypassed.
-        """
+    def _acquire_cache_lock(self, lock: SoftFileLock):
+        """Try to acquire cache lock. After a certain time bypass it."""
         started = time.monotonic()
         first_warning = False
 
@@ -172,7 +168,7 @@ class RepoCloner(Cloner):
             try:
                 lock.acquire(timeout=20)
                 logger.info("Cache lock acquired.")
-                return True
+                return
 
             except Timeout:
                 waited = int(time.monotonic() - started)
@@ -192,7 +188,9 @@ class RepoCloner(Cloner):
                         f"Cache remained locked past the set wait time of {CACHE_MAX_WAIT} seconds. "
                         "Force proceeding without acquiring cache lock..."
                     )
-                    return False
+                    lock.break_lock()
+                    lock.acquire()
+                    return
 
     def _get_manifest_hostname(self, url: str) -> str:
         """Extracts the hostname from a given URL.

--- a/src/sc/clone/cloners/repo_cloner.py
+++ b/src/sc/clone/cloners/repo_cloner.py
@@ -31,8 +31,8 @@ from sc_manifest_parser import ScManifest
 logger = logging.getLogger(__name__)
 
 REPO_CACHE_DIR = Path.home() / ".caches"
-CACHE_LOCK_PATH = REPO_CACHE_DIR / ".lock"
-CACHE_MAX_WAIT = 600
+CACHE_LOCK_PATH = REPO_CACHE_DIR / ".sc_lock"
+CACHE_MAX_WAIT = 300
 
 class RepoClonerConfig(BaseModel):
     """
@@ -86,32 +86,15 @@ class RepoCloner(Cloner):
     def _clone_with_cache(self, directory: Path):
         REPO_CACHE_DIR.mkdir(exist_ok=True)
 
-        started = time.monotonic()
         lock = FileLock(CACHE_LOCK_PATH)
-
-        logger.info("Acquiring cache lock.")
-        while True:
-            try:
-                lock.acquire(timeout=20)
-                break
-            except Timeout:
-                waited = int(time.monotonic() - started)
-                if waited < CACHE_MAX_WAIT:
-                    logger.info(
-                        f"Cache is in use by another process, waited {waited} seconds..."
-                    )
-                else:
-                    logger.error(
-                        f"Cache remained locked past the set wait time of {CACHE_MAX_WAIT} seconds."
-                    )
-                    sys.exit(1)
-        logger.info("Cache lock acquired.")
+        lock_acquired = self._acquire_cache_lock(lock)
 
         try:
             reference = self._cache()
             self._clone(directory, reference)
         finally:
-            lock.release()
+            if lock_acquired:
+                lock.release()
 
     def _clone(self, directory: Path, reference: Path | None = None):
         self._init_repo(directory=directory, reference=reference)
@@ -175,6 +158,41 @@ class RepoCloner(Cloner):
         except subprocess.CalledProcessError as e:
             logger.error(f"repo init error: {e}")
             sys.exit(1)
+
+    def _acquire_cache_lock(self, lock: FileLock) -> bool:
+        """Try to acquire cache lock. After a certain time bypass it.
+
+        Return True if lock acquired or False if bypassed.
+        """
+        started = time.monotonic()
+        first_warning = False
+
+        logger.info("Acquiring cache lock.")
+        while True:
+            try:
+                lock.acquire(timeout=20)
+                logger.info("Cache lock acquired.")
+                return True
+
+            except Timeout:
+                waited = int(time.monotonic() - started)
+                if waited < CACHE_MAX_WAIT:
+                    logger.info(
+                        f"Cache is in use by another process, waited {waited} seconds..."
+                    )
+
+                    if first_warning == False:
+                        logger.info(f"SC will wait for {CACHE_MAX_WAIT} seconds before bypassing.")
+                        logger.info(
+                            "The cache is user specific, if you believe there is no way your cache "
+                            f"should be in use you could try deleting the lock: {CACHE_LOCK_PATH}")
+                        first_warning = True
+                else:
+                    logger.warning(
+                        f"Cache remained locked past the set wait time of {CACHE_MAX_WAIT} seconds. "
+                        "Force proceeding without acquiring cache lock..."
+                    )
+                    return False
 
     def _get_manifest_hostname(self, url: str) -> str:
         """Extracts the hostname from a given URL.


### PR DESCRIPTION
Implement cache locking. Went with a timeout of 10 minutes where if a user is waiting for more than 10 mins it will error out for them.

The previous version waited for 5 minutes and if it was still locked beyond then it bypassed it for the user. This does mean it never gets hard locked but also could cause a long clone (that is locking the cache) to then error which could be frustrating for users.

I'm thinking of keeping the hardline solution of the cache is locked unless you go and delete the lockfile and see if any users get stuck and if so we can look at alternatives. But open to suggestions.

Edit 1:
Decided to go with 5 minutes and a bypass to match old sc instead of 10 minutes and an error.